### PR TITLE
Simple fix for column() api function

### DIFF
--- a/js/api/api.columns.js
+++ b/js/api/api.columns.js
@@ -38,7 +38,7 @@ var __column_selector = function ( settings, selector, opts )
 			];
 		}
 		else {
-			var match = s.match( __re_column_selector );
+            var match = $.type(s) === "string" && s.match( __re_column_selector );
 
 			if ( match ) {
 				switch( match[2] ) {


### PR DESCRIPTION
Currently the column() api function is broken when a jquery object is passed as the selector.

Check out this fiddle: http://jsfiddle.net/chrisrudd/222vu/
