### PR TITLE
Added null check on init

### DIFF
--- a/js/core/core.constructor.js
+++ b/js/core/core.constructor.js
@@ -306,7 +306,7 @@ if ( rowOne.length ) {
 	$.each( _fnGetRowElements( oSettings, rowOne[0] ).cells, function (i, cell) {
 		var col = oSettings.aoColumns[i];
 
-		if ( col.mData === i ) {
+		if ( col != null && col.mData === i ) {
 			var sort = a( cell, 'sort' ) || a( cell, 'order' );
 			var filter = a( cell, 'filter' ) || a( cell, 'search' );
 


### PR DESCRIPTION
This fixed the issue I was having when destroying a datatable with a certain number of columns (set through the "columns" property when initializing).  `col` was null in cases where the second table that was generated had less columns that the one before.

For more info I initially described the problem [here](http://www.datatables.net/forums/discussion/20524/destroy-issue).
