### PR TITLE
ability to trigger processing from the api

### DIFF
--- a/js/api/api.core.js
+++ b/js/api/api.core.js
@@ -51,6 +51,27 @@ _api_register( 'data()', function () {
 } );
 
 
+/**
+ * Display the processing message. Only effective if processing option was enable
+ * at instanciation
+ *
+ *  @param {boolean} active true to show processing, false to hide processing
+ */
+_api_register( 'processing()', function ( activate ) {
+	return this.iterator( 'table', function ( settings ) {
+		_fnProcessingDisplay( settings, activate );
+	} );
+} );
+
+/**
+ * Allows to get the processing status. True if shown, false is not
+ */
+_api_register( 'isProcessing()', function () {
+	return this.iterator( 'table', function ( settings ) {
+		return $(settings.aanFeatures.r).is(":visible");
+	} )[0];
+} );
+
 _api_register( 'destroy()', function ( remove ) {
 	remove = remove || false;
 


### PR DESCRIPTION
Add 2 method to the api :

`api.processing(true/false)` and `isProcessing()`

Example of usage :

``` javascript

    $(document).ready(function() {
            var api = $('#example').DataTable({
            processing:true
                    });

                    console.log(api.isProcessing()); // false

                    api.processing(true);

                    console.log(api.isProcessing()); // true

                    setTimeout(function(){
                                        api.processing(false);
                                        console.log(api.isProcessing()); //false
                    },1500);

```
