### PR TITLE
Ability to use a function as a selector in the API

### DIFF
--- a/js/api/api.rows.js
+++ b/js/api/api.rows.js
@@ -49,6 +49,15 @@ var __row_selector = function ( settings, selector, opts )
 			}
 		}
 
+		// if the selector is a function then it wraps it into a new function that will then attach the data object to it
+
+		if ( typeof sel === 'function' ) {
+			var _sel = sel;
+			sel = function( idx, node ){
+				return _sel.call( this, idx, node, settings.aoData[ this._DT_RowIndex ]._aData );
+			}
+		}
+
 		// Selector - jQuery selector string, array of nodes or jQuery object/
 		// As jQuery's .filter() allows jQuery objects to be passed in filter,
 		// it also allows arrays, so this will cope with all three options

--- a/js/api/api.selectors.js
+++ b/js/api/api.selectors.js
@@ -9,7 +9,7 @@ var _selector_run = function ( selector, select )
 
 	// Can't just check for isArray here, as an API or jQuery instance might be
 	// given with their array like look
-	if ( ! selector || typeof selector === 'string' || selector.length === undefined ) {
+	if ( ! selector || typeof selector === 'function' || typeof selector === 'string' || selector.length === undefined ) {
 		selector = [ selector ];
 	}
 


### PR DESCRIPTION
This is a quick and easy update, may be you want to fix a few things, I've tested it with my actual use case in which i use the data to attached to the rows, for which It's then an settings.aoData[x]._aData ( I'm not sure if in other cases that's true

Ok, for the use case, its quite simple, right now you have the ability to filter the rows by jQuery selectors, or by number.. but with this patch you would be able to do something like 

```javascript
_dt.api().row( function( idx, node, data){
  return data.get("id") == 150;
}).....
```
And that would get you the row representing the data model with id 150

In my usage case I'm using Backbone, and I'm attaching the model to the row, for this reason I can just call the backbone function _.get("id")_ but this should actually send whatever is attached to that particular data row

Hope you like this idea

Cheers!

Giancarlo