### PR TITLE
Update core.filter.js

### DIFF
--- a/js/core/core.filter.js
+++ b/js/core/core.filter.js
@@ -185,9 +185,11 @@ function _fnFilterColumn ( settings, searchStr, colIdx, regex, smart, caseInsens
 	var data;
 	var display = settings.aiDisplay;
 	var rpSearch = _fnFilterCreateSearch( searchStr, regex, smart, caseInsensitive );
+	var filterCols = settings.aoColumns.filter(function(s) { return s.visible; });
 
 	for ( var i=display.length-1 ; i>=0 ; i-- ) {
-		data = settings.aoData[ display[i] ]._aFilterData[ colIdx ];
+		var filterIdx = filterCols.indexOf(settings.aoColumns[colIdx]);
+		data = settings.aoData[ display[i] ]._aFilterData[ filterIdx ];
 
 		if ( ! rpSearch.test( data ) ) {
 			display.splice( i, 1 );


### PR DESCRIPTION
Fix for table.column(name).search(needle).draw() when there are hidden columns.

The _aFilterData only contains visible data but it is used to filter column level searches.  This causes column index mismatching.  This simply checks the full column list vs the filtered list to ensure the proper index is used.

Eg: http://71.205.34.197/php-site/?view=edit_fields&parent=3
In this table(scroll down) there is a hidden field at index 0 of the table.
