### PR TITLE
Improved last page calculation.

### DIFF
--- a/js/core/core.support.js
+++ b/js/core/core.support.js
@@ -219,7 +219,7 @@ function _fnLengthOverflow ( settings )
 		len = settings._iDisplayLength;
 
 	/* If we have space to show extra rows (backing up from the end point - then do so */
-	if ( end === settings.fnRecordsDisplay() )
+	if (start >= end) 
 	{
 		start = end - len;
 	}


### PR DESCRIPTION
Improved last page calculation when page size is changed on last page.
e.g. Suppose there are total 12 records and page size is set to 5 records/page. Go to last page, which should be 3, change page size to 10. Page#2 should be selected and it should show 2 records on it.
