### PR TITLE
Adding `searchDelay` property to set time delay for Server-Side Processing

### DIFF
--- a/js/core/core.constructor.js
+++ b/js/core/core.constructor.js
@@ -136,6 +136,7 @@ _fnMap( oSettings, oInit, [
 	"fnStateLoadCallback",
 	"fnStateSaveCallback",
 	"renderer",
+	"searchDelay",
 	[ "iCookieDuration", "iStateDuration" ], // backwards compat
 	[ "oSearch", "oPreviousSearch" ],
 	[ "aoSearchCols", "aoPreSearchCols" ],

--- a/js/core/core.filter.js
+++ b/js/core/core.filter.js
@@ -29,7 +29,6 @@ function _fnFeatureHtmlFilter ( settings )
 		/* Update all other filter input elements for the new display */
 		var n = features.f;
 		var val = !this.value ? "" : this.value; // mental IE8 fix :-(
-
 		/* Now do the filter */
 		if ( val != previousSearch.sSearch ) {
 			_fnFilterComplete( settings, {
@@ -50,7 +49,7 @@ function _fnFeatureHtmlFilter ( settings )
 		.bind(
 			'keyup.DT search.DT input.DT paste.DT cut.DT',
 			_fnDataSource( settings ) === 'ssp' ?
-				_fnThrottle( searchFn, 400 ):
+				_fnThrottle( searchFn, (settings.searchDelay || 400)):
 				searchFn
 		)
 		.bind( 'keypress.DT', function(e) {
@@ -263,13 +262,13 @@ function _fnFilterCreateSearch( search, regex, smart, caseInsensitive )
 	search = regex ?
 		search :
 		_fnEscapeRegex( search );
-	
+
 	if ( smart ) {
 		/* For smart filtering we want to allow the search to work regardless of
 		 * word order. We also want double quoted text to be preserved, so word
 		 * order is important - a la google. So this is what we want to
 		 * generate:
-		 * 
+		 *
 		 * ^(?=.*?\bone\b)(?=.*?\btwo three\b)(?=.*?\bfour\b).*$
 		 */
 		var a = $.map( search.match( /"[^"]+"|[^ ]+/g ) || '', function ( word ) {
@@ -403,4 +402,3 @@ function _fnSearchToHung ( obj )
 		bCaseInsensitive: obj.caseInsensitive
 	};
 }
-

--- a/js/model/model.defaults.js
+++ b/js/model/model.defaults.js
@@ -1699,7 +1699,7 @@ DataTable.defaults = {
 		 * However, multiple different tables on the page can use different
 		 * decimal place characters.
 		 *  @type string
-		 *  @default 
+		 *  @default
 		 *
 		 *  @dtopt Language
 		 *  @name DataTable.defaults.language.decimal
@@ -1864,7 +1864,7 @@ DataTable.defaults = {
 		/**
 		 * Assign a `placeholder` attribute to the search `input` element
 		 *  @type string
-		 *  @default 
+		 *  @default
 		 *
 		 *  @dtopt Language
 		 *  @name DataTable.defaults.language.searchPlaceholder
@@ -2047,7 +2047,7 @@ DataTable.defaults = {
 	 * * `full` - 'First', 'Previous', 'Next' and 'Last' buttons
 	 * * `full_numbers` - 'First', 'Previous', 'Next' and 'Last' buttons, plus
 	 *   page numbers
-	 *  
+	 *
 	 * Further methods can be added using {@link DataTable.ext.oPagination}.
 	 *  @type string
 	 *  @default simple_numbers
@@ -2155,7 +2155,6 @@ DataTable.defaults = {
 	 */
 	"sServerMethod": "GET",
 
-
 	/**
 	 * DataTables makes use of renderers when displaying HTML elements for
 	 * a table. These renderers can be added or modified by plug-ins to
@@ -2171,8 +2170,25 @@ DataTable.defaults = {
 	 *  @name DataTable.defaults.renderer
 	 *
 	 */
-	"renderer": null
+	"renderer": null,
+
+  /**
+   * DataTables, as of v1.10, has built in search throttling for tables that
+   * use server-side processing. The default delay time for this throttling
+   * is 400ms, unless overriden below.
+	 *  @type int
+	 *  @default null
+	 *
+	 *  @dtopt Options
+	 *  @name DataTable.defaults.searchDelay
+	 *  @example
+	 *    $(document).ready( function() {
+	 *      $('#example').dataTable( {
+	 *        "searchDelay": 800
+	 *      } );
+	 *    } )
+  */
+	"searchDelay": null
 };
 
 _fnHungarianMap( DataTable.defaults );
-

--- a/js/model/model.settings.js
+++ b/js/model/model.settings.js
@@ -1,5 +1,3 @@
-
-
 /**
  * DataTables settings object - this holds all the information needed for a
  * given table, including configuration, data and current application of the
@@ -873,5 +871,12 @@ DataTable.models.oSettings = {
 	 *  @type object
 	 *  @default {}
 	 */
-	"oPlugins": {}
+	"oPlugins": {},
+
+	/**
+	 * Search throttling delay
+	 *  @type int
+	 *  @default null
+	 */
+	"searchDelay": null
 };


### PR DESCRIPTION
## Adding `searchDelay` property to set time delay for Server-Side Processing

Note: Related to discussion in https://github.com/DataTables/DataTables/issues/390

This PR adds  a `searchDelay` property to the internal and external settings objects allowing the server-side search throttling time delay to be configurable. The default time is still set to 400ms. If the user has not entered in a  value for the `searchDelay` property then the default is used.

Example:

``` javascript
        $(document).ready( function() {
             $('#example').dataTable( {
                "searchDelay": 800
             } );
       } );
```

Let me know if theres additional changes needed. 
