### PR TITLE
BugFix: Prefer ajax over sAjaxSource

### DIFF
--- a/js/core/core.ajax.js
+++ b/js/core/core.ajax.js
@@ -100,7 +100,7 @@ function _fnBuildAjax( oSettings, data, fn )
 	{
 		// DataTables 1.9- compatibility
 		oSettings.fnServerData.call( instance,
-			oSettings.sAjaxSource,
+			ajax || oSettings.sAjaxSource,
 			$.map( data, function (val, key) { // Need to convert back to 1.9 trad format
 				return { name: key, value: val };
 			} ),


### PR DESCRIPTION
According to a comment in https://github.com/DataTables/DataTablesSrc/blob/master/js/api/api.ajax.js#L121, `ajax` has priority over `sAjaxSource`.

This is not true in https://github.com/DataTables/DataTablesSrc/blob/master/js/core/core.ajax.js#L103 if `fnServerData` is set, where only `sAjaxSource` is used.

I ran into this bug in combination with https://github.com/l-lin/angular-datatables, where even after changing the `sAjaxSource` property the initial url is used in all subsequent calls to `fnServerData`.