### PR TITLE
Allow overriding colors when importing SCSS file

### DIFF
--- a/css/jquery.dataTables.scss
+++ b/css/jquery.dataTables.scss
@@ -2,29 +2,33 @@
  //
  // Colour customisation
  //
+ // `!default` allows overriding variables that are defined before @import
+ //
 
 // Border between the header (and footer) and the table body
-$table-header-border: 1px solid #111;
+$table-header-border: 1px solid #111 !default;
 
 // Border of rows / cells
-$table-body-border: 1px solid #ddd;
+$table-body-border: 1px solid #ddd !default;
 
 // Row background colour (hover, striping etc are all based on this colour and
 // calculated automatically)
-$table-row-background: #ffffff;
+$table-row-background: #ffffff !default;
 
 // Row colour, when selected (tr.selected)
-$table-row-selected: #B0BED9;
+$table-row-selected: #B0BED9 !default;
 
 // Text colour of the interaction control elements (info, filter, paging etc)
-$table-control-color: #333;
+$table-control-color: #333 !default;
 
 // Highlight colour of the paging button for the current page
-$table-paging-button-active: #dcdcdc;
+$table-paging-button-active: #dcdcdc !default;
 
 // Hover colour of paging buttons on mouse over
-$table-paging-button-hover: #111;
+$table-paging-button-hover: #111 !default;
 
+// Colour to use when shading
+$table-shade: black !default;
 
 
 //
@@ -35,7 +39,7 @@ $table-paging-button-hover: #111;
 }
 
 @function shade( $color, $percent ) {
-	@return mix(black, $color, $percent);
+	@return mix($table-shade, $color, $percent);
 }
 
 @mixin gradient( $from, $to ) {


### PR DESCRIPTION
### 1. Add `!default`

`!default` allows overriding variables that are defined before `@import`

In my project, I'm importing the SCSS file into another file, and I'd like to define custom variables there. By adding `!default`, if the variables are already defined, the previously defined variables are used.

Here's the code from my project:

```
$table-row-background: #ffffcc;

@import "../../datatables-src/css/jquery.dataTables.scss";
```

---
### 2. Customizable shading color

If I wanted to shade using blue, I could use:

```
$table-row-background: #eeffff;
$table-shade: #0000ff;
@import "../../datatables-src/css/jquery.dataTables.scss";
```
