### PR TITLE
Fix for CommonJS/Browserify

### DIFF
--- a/js/DataTables.js
+++ b/js/DataTables.js
@@ -35,7 +35,7 @@
 	}
     else if ( typeof exports === 'object' ) {
         // Node/CommonJS
-        factory( require( 'jquery' ) );
+        module.exports = factory( require( 'jquery' ) );
     }
 	else if ( jQuery && !jQuery.fn.dataTable ) {
 		// Define using browser globals otherwise


### PR DESCRIPTION
I'm not sure whether this breaks any other CJS implementation, but the only one you're likely to have to worry about is Browserify.

This relates to https://github.com/DataTables/DataTables/issues/434
