### PR TITLE
Change height adjustment on scroller feature to max-height from height

### DIFF
--- a/js/core/core.scrolling.js
+++ b/js/core/core.scrolling.js
@@ -92,7 +92,7 @@ function _fnFeatureHtmlTable ( settings )
 			$(_div, { 'class': classes.sScrollBody } )
 				.css( {
 					overflow: 'auto',
-					height: size( scrollY ),
+					'max-height': size( scrollY ),
 					width: size( scrollX )
 				} )
 				.append( table )


### PR DESCRIPTION
This seems like such an obvious thing to do that I'm wondering if there's a feature that would allow this behaviour, but since I didn't find such a thing I decided to just modify the source. 

The original code leaves some blank space if there's not enough rows to fill the height. Going with max-height allows the table to adjust to whatever rows there are until that height is reached, and then starts scrolling.
