### PR TITLE
move `eq` jQuery selector outside of selector

### DIFF
--- a/js/core/core.constructor.js
+++ b/js/core/core.constructor.js
@@ -259,7 +259,7 @@ if ( oInit.asStripeClasses === null )
 
 /* Remove row stripe classes if they are already on the table row */
 var stripeClasses = oSettings.asStripeClasses;
-var rowOne = $('tbody tr:eq(0)', this);
+var rowOne = $('tbody tr', this).eq(0);
 if ( $.inArray( true, $.map( stripeClasses, function(el, i) {
 	return rowOne.hasClass(el);
 } ) ) !== -1 ) {


### PR DESCRIPTION
This is a **tiny** change. I hope that makes it easy to merge :-)

## Background
While debugging another issue (which was not caused by DataTables), I stumbled upon a minute performance enhancement that could be made in DataTables. When removing row stripe classes, the following line is used to retrieve the first row of the table:
```
var rowOne = $('tbody tr:eq(0)', this);
```

## Problem
While this works, it forces jQuery to use non-native css-selectors. See the jQuery docs on the eq() selector: http://api.jquery.com/eq-selector/. Here's a quote:

```
Because :eq() is a jQuery extension and not part of the CSS specification, queries using :eq() cannot take advantage of the performance boost provided by the native DOM querySelectorAll() method. For better performance in modern browsers, use $("your-pure-css-selector").eq(index) instead.
```

## Solution
Replace the selector a valid css selector and a subsequent call to the `.eq()` method:
```
var rowOne = $('tbody tr', this).eq(0);
```

Here is a jsfiddle to outline the difference between the two:
Before update: http://jsfiddle.net/1829ytso/
After update: http://jsfiddle.net/1829ytso/1/


