### PR TITLE
TypeError: s.match is not a function

### DIFF
--- a/js/core/core.sizing.js
+++ b/js/core/core.sizing.js
@@ -317,6 +317,10 @@ function _fnStringToCss( s )
 			'0px' :
 			s+'px';
 	}
+	
+	if (typeof s.match == 'undefined') {
+		return null;
+	}
 
 	// Check it has a unit character already
 	return s.match(/\d$/) ?


### PR DESCRIPTION
When initializing DataTables with 
```javascript
"ajax": {
	        "url": "/some/action/index",
	        "type": "POST"
	    },
"paging": true,
"dom": 'T<"clear">lrtip',
"serverSide": true,
"processing": true,
"scrollX": true,
```
Actually it seem's like it doesn't matter the value of "scrollX" at all, if you include it as part of the options the type error appears. I don't know if the problem here is of a deeper nature but this type test should always be present anyway and in my case it fixed the problem.