### PR TITLE
Added images to bower 'main'section

### DIFF
--- a/descriptors/bower.json
+++ b/descriptors/bower.json
@@ -3,7 +3,8 @@
 	"version": "_VERSION_",
 	"main": [
 		"media/js/jquery.dataTables.js",
-		"media/css/jquery.dataTables.css"
+		"media/css/jquery.dataTables.css",
+		"media/images/*.png"
 	],
 	"dependencies": {
 		"jquery": ">=1.7.0"


### PR DESCRIPTION
I did some searching through the forums and issues but couldn't find any reason why the images shouldn't be included in the Bower `main` section. This simply adds that folder (the PNGs) to the list of files that should be included in a production install.