### PR TITLE
Allow user to specify static-width columns while bAutoWidth is enabled

### DIFF
--- a/js/core/core.sizing.js
+++ b/js/core/core.sizing.js
@@ -84,8 +84,11 @@ function _fnCalculateColumnWidths ( oSettings )
 				columnIdx = visibleColumns[i];
 				column = columns[ columnIdx ];
 
-				$( _fnGetWidestNode( oSettings, columnIdx ) )
-					.clone( false )
+				var td = (column.sWidth && !column.bResizable) ?
+					$( '<td />', {style: 'width='+column.sWidth+' !important;'} ) :
+					$( _fnGetWidestNode( oSettings, columnIdx ) );
+
+				td.clone( false )
 					.append( column.sContentPadding )
 					.appendTo( tr );
 			}
@@ -94,7 +97,7 @@ function _fnCalculateColumnWidths ( oSettings )
 		// Table has been built, attach to the document so we can work with it
 		tmpTable.appendTo( tableContainer );
 
-		// When scrolling (X or Y) we want to set the width of the table as 
+		// When scrolling (X or Y) we want to set the width of the table as
 		// appropriate. However, when not scrolling leave the table width as it
 		// is. This results in slightly different, but I think correct behaviour
 		if ( scrollX && scrollXInner ) {

--- a/js/model/model.column.js
+++ b/js/model/model.column.js
@@ -42,6 +42,13 @@ DataTable.models.oColumn = {
 	"asSorting": null,
 
 	/**
+	 * Flag to indicate if the column should allow resizing or not.
+	 * If set false, then column size will only be calculated once.
+	 *  @type boolean
+	 */
+	"bResizable": true,
+
+	/**
 	 * Flag to indicate if the column is searchable, and thus should be included
 	 * in the filtering or not.
 	 *  @type boolean


### PR DESCRIPTION
This is both for the user's flexibility, as well as performance. 

Regarding performance impact, in my initial testing on a table with 500 rows, 10 columns, my machine averages ~100ms in `_fnCalculateColumnWidths`on initial load. Obviously, usually pagination is the best solution, but this doesn't seem like a very rare use case. If I know that 8 of those rows can be static-width, and only wish to have the other 2 calculated, and use this feature, that number is cut that down to ~26ms. 

Of course, the main reason for this feature is to provide additional styling options to the user. 
