### PR TITLE
Call _fnAjaxDataSrc before setting recordsTotal

### DIFF
--- a/js/core/core.ajax.js
+++ b/js/core/core.ajax.js
@@ -1,5 +1,3 @@
-
-
 /**
  * Create an Ajax call based on the table's settings, taking into account that
  * parameters can have multiple forms, and backwards compatibility.
@@ -284,6 +282,7 @@ function _fnAjaxUpdateDraw ( settings, json )
 		return json[old] !== undefined ? json[old] : json[modern];
 	};
 
+	var data = _fnAjaxDataSrc( settings, json );
 	var draw            = compat( 'sEcho',                'draw' );
 	var recordsTotal    = compat( 'iTotalRecords',        'recordsTotal' );
 	var recordsFiltered = compat( 'iTotalDisplayRecords', 'recordsFiltered' );
@@ -300,7 +299,6 @@ function _fnAjaxUpdateDraw ( settings, json )
 	settings._iRecordsTotal   = parseInt(recordsTotal, 10);
 	settings._iRecordsDisplay = parseInt(recordsFiltered, 10);
 
-	var data = _fnAjaxDataSrc( settings, json );
 	for ( var i=0, ien=data.length ; i<ien ; i++ ) {
 		_fnAddData( settings, data[i] );
 	}
@@ -342,4 +340,3 @@ function _fnAjaxDataSrc ( oSettings, json )
 		_fnGetObjectDataFn( dataSrc )( json ) :
 		json;
 }
-


### PR DESCRIPTION
_fnAjaxDataSrc will in turn call _fnGetObjectDataFn, which
can be specified by the dataSrc method.

This way the dataSrc can set the recordsTotal parameter on
the json data and the changes will be read into the
recordsTotal/recordsFiltered variables.

I've tested this on my development site and it works fine there.

In my case the server does not return the proper "recordsTotal" method
but it can be calculated by other means.

If you'd prefer an alternative method, perhaps the recordsTotal could be
extended to optionally call a function in order to retrieve the counts.  I'll
take a stab at that if you think it'd be better.