### PR TITLE
Add brazilian currency support for sorting

### DIFF
--- a/docs/option/columns.type.xml
+++ b/docs/option/columns.type.xml
@@ -21,11 +21,12 @@
       * Sorting - sorted numerically
       * Filtering - no effect
     * `num-fmt` - Numeric sorting of formatted numbers. Numbers which are formatted with thousands separators, currency symbols or a percentage indicator will be sorted numerically automatically by DataTables.
-      * Supported built-in currency symbols are `$`, `£`, `€` and `¥`.
+      * Supported built-in currency symbols are `$`, `£`, `€`, `¥` and `R$`.
       * Supported built-in thousands separators are `'` and `,`. 
       * Examples:
         * $100,000 - sorted as `100000`
         * £10'000 - sorted as `10000`
+        * R$1000 - sorted as `1000`
         * 5'000 - sorted as 5000
         * 40% - sorted as 40
       * Sorting - sorted numerically

--- a/js/core/core.internal.js
+++ b/js/core/core.internal.js
@@ -31,7 +31,7 @@ var _re_escape_regex = new RegExp( '(\\' + [ '/', '.', '*', '+', '?', '|', '(', 
 
 // U+2009 is thin space and U+202F is narrow no-break space, both used in many
 // standards as thousands separators
-var _re_formatted_numeric = /[',$£€¥%\u2009\u202F]/g;
+var _re_formatted_numeric = /[',R$£€¥%\u2009\u202F]/g;
 
 
 var _empty = function ( d ) {

--- a/js/core/core.internal.js
+++ b/js/core/core.internal.js
@@ -31,7 +31,7 @@ var _re_escape_regex = new RegExp( '(\\' + [ '/', '.', '*', '+', '?', '|', '(', 
 
 // U+2009 is thin space and U+202F is narrow no-break space, both used in many
 // standards as thousands separators
-var _re_formatted_numeric = /[',R$£€¥%\u2009\u202F]/g;
+var _re_formatted_numeric = /[',$£€¥%\u2009\u202F]|(R[$]{1})/g;
 
 
 var _empty = function ( d ) {


### PR DESCRIPTION
The [brazilian currency's (real) symbol](http://en.wikipedia.org/wiki/Brazilian_real) is "R$". As only "$" is escaped, in this case, based on [columns.type](https://datatables.net/reference/option/columns.type), any column that has a R$ value (e.g.: R$6000, R$500, ...) breaks the sorting. With this minor change, brazilian currency can be supported and I didn't see any other impact while using the modified version.