### PR TITLE
Add a pre-filter callback as a configuration option

### DIFF
--- a/js/core/core.constructor.js
+++ b/js/core/core.constructor.js
@@ -141,6 +141,7 @@ _fnMap( oSettings, oInit, [
 	"iTabIndex",
 	"fnStateLoadCallback",
 	"fnStateSaveCallback",
+	"fnPreFilterCallback",
 	"renderer",
 	"searchDelay",
 	[ "iCookieDuration", "iStateDuration" ], // backwards compat

--- a/js/core/core.filter.js
+++ b/js/core/core.filter.js
@@ -12,6 +12,7 @@ function _fnFeatureHtmlFilter ( settings )
 	var language = settings.oLanguage;
 	var previousSearch = settings.oPreviousSearch;
 	var features = settings.aanFeatures;
+	var preFilterCallback = settings.fnPreFilterCallback;
 	var input = '<input type="search" class="'+classes.sFilterInput+'"/>';
 
 	var str = language.sSearch;
@@ -29,6 +30,9 @@ function _fnFeatureHtmlFilter ( settings )
 		/* Update all other filter input elements for the new display */
 		var n = features.f;
 		var val = !this.value ? "" : this.value; // mental IE8 fix :-(
+		if (preFilterCallback) {
+			val = preFilterCallback(val);
+		}
 
 		/* Now do the filter */
 		if ( val != previousSearch.sSearch ) {

--- a/js/model/model.defaults.js
+++ b/js/model/model.defaults.js
@@ -1009,6 +1009,27 @@ DataTable.defaults = {
 
 
 	/**
+	 * Called when the value is obtained from the filter input and can be used to
+	 * manipulate the search string (for example, to remove accents).
+	 *  @type function
+	 *  @param {string} search value to be modified
+	 *  @returns {string} modified search value
+	 *
+	 *  @dtopt Callbacks
+	 *  @name DataTable.defaults.preFilterCallback
+	 *
+	 *  @example
+	 *    $(document).ready( function() {
+		 *      $('#example').dataTable( {
+		 *        "preFilterCallback": function( val ) {
+		 *          return removeDiacritics(val);
+		 *        }
+		 *      } );
+		 *    } );		 */
+	"fnPreFilterCallback": null,
+
+
+	/**
 	 * This function allows you to 'post process' each row after it have been
 	 * generated for each table draw, but before it is rendered on screen. This
 	 * function might be used for setting the row class name etc.


### PR DESCRIPTION
I've added a callback configuration option to allow the filter term to be preprocessed. The obvious use case is to remove accents without having to bind to the filter input's keyup event (see http://www.datatables.net/plug-ins/filtering/type-based/accent-neutralise).