### PR TITLE
Remove label elements to improve compatibility with bootstrap input-groups

### DIFF
--- a/js/core/core.filter.js
+++ b/js/core/core.filter.js
@@ -23,7 +23,7 @@ function _fnFeatureHtmlFilter ( settings )
 			'id': ! features.f ? tableId+'_filter' : null,
 			'class': classes.sFilter
 		} )
-		.append( $('<label/>' ).append( str ) );
+		append( str );
 
 	var searchFn = function() {
 		/* Update all other filter input elements for the new display */

--- a/js/core/core.length.js
+++ b/js/core/core.length.js
@@ -37,12 +37,12 @@ function _fnFeatureHtmlLength ( settings )
 		select[0][ i ] = new Option( language[i], lengths[i] );
 	}
 
-	var div = $('<div><label/></div>').addClass( classes.sLength );
+	var div = $('<div></div>').addClass( classes.sLength );
 	if ( ! settings.aanFeatures.l ) {
 		div[0].id = tableId+'_length';
 	}
 
-	div.children().append(
+	div.append(
 		settings.oLanguage.sLengthMenu.replace( '_MENU_', select[0].outerHTML )
 	);
 


### PR DESCRIPTION
Bootstrap's [input groups](http://getbootstrap.com/components/#input-groups) can be nice for filtering and selecting, but Datatables' hard-coded labels don't allow for this.

 * [Currently](https://jsfiddle.net/tomxland/2st8bxma/1/embedded/result/)
 * [After this patch](https://jsfiddle.net/tomxland/fmwt7znx/1/embedded/result/) - visual differences only as I can't pull the patched datatables js from the CDN



