### PR TITLE
Add preRowPopulate callback option

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -16,7 +16,7 @@ This separation allows developers who simply want to use DataTables as is, to do
 
 ## Building
 
-DataTables can be built using the `make.sh` script in the `/scripts` directory of this repo. Simply check out the repo and run `make.sh --help` to get a full list of the options available for the build process. `make.sh build` will be the most common (with `make.sh build debug` available for quick testing - it skips the minification steps for speed).
+DataTables can be built using the `make.sh` script in the `/build` directory of this repo. Simply check out the repo and run `make.sh --help` to get a full list of the options available for the build process. `make.sh build` will be the most common (with `make.sh build debug` available for quick testing - it skips the minification steps for speed).
 
 A number of programs are required out your computer to be able to build DataTables:
 

--- a/js/core/core.constructor.js
+++ b/js/core/core.constructor.js
@@ -164,6 +164,7 @@ _fnCallbackReg( oSettings, 'aoStateSaveParams',    oInit.fnStateSaveParams,   'u
 _fnCallbackReg( oSettings, 'aoStateLoadParams',    oInit.fnStateLoadParams,   'user' );
 _fnCallbackReg( oSettings, 'aoStateLoaded',        oInit.fnStateLoaded,       'user' );
 _fnCallbackReg( oSettings, 'aoRowCallback',        oInit.fnRowCallback,       'user' );
+_fnCallbackReg( oSettings, 'aoRowPreRowPopulate',  oInit.fnPreRowPopulate,    'user' );
 _fnCallbackReg( oSettings, 'aoRowCreatedCallback', oInit.fnCreatedRow,        'user' );
 _fnCallbackReg( oSettings, 'aoHeaderCallback',     oInit.fnHeaderCallback,    'user' );
 _fnCallbackReg( oSettings, 'aoFooterCallback',     oInit.fnFooterCallback,    'user' );

--- a/js/core/core.draw.js
+++ b/js/core/core.draw.js
@@ -32,6 +32,8 @@ function _fnCreateTr ( oSettings, iRow, nTrIn, anTds )
 		/* Special parameters can be given by the data source to be used on the row */
 		_fnRowAttributes( row );
 
+        _fnCallbackFire( oSettings, 'aoRowPreRowPopulate', null, [nTr, rowData, iRow] );
+
 		/* Process each column */
 		for ( i=0, iLen=oSettings.aoColumns.length ; i<iLen ; i++ )
 		{
@@ -169,7 +171,7 @@ function _fnBuildHead( oSettings )
 	if ( createHeader ) {
 		_fnDetectHeader( oSettings.aoHeader, thead );
 	}
-	
+
 	/* ARIA role for the rows */
  	$(thead).find('>tr').attr('role', 'row');
 

--- a/js/model/model.defaults.js
+++ b/js/model/model.defaults.js
@@ -786,6 +786,33 @@ DataTable.defaults = {
 	"bStateSave": false,
 
 
+    /**
+     * This function is called immediately before column data is populated
+     * into a row, allowing manipulation of the row data prior to td generation.
+     *  @type function
+     *  @param {node} row "TR" element for the current row
+     *  @param {array} data Raw data array for this row
+     *  @param {int} dataIndex The index of this row in the internal aoData array
+     *
+     *  @dtopt Callbacks
+     *  @name DataTable.defaults.preRowPopulate
+     *
+     *  @example
+     *    $(document).ready( function() {
+     *      $('#example').dataTable( {
+     *        "preRowPopulate": function( row, data, dataIndex ) {
+     *          var $dtRow = this.api().row(row);
+     *          // swap this row data if matches some condition
+     *          if ( data.a == "b" )
+     *          {
+     *            $dtRow.data({a: "a"});
+     *          }
+     *        }
+     *      } );
+     *    } );
+     */
+    "fnPreRowPopulate": null,
+
 	/**
 	 * This function is called when a TR element is created (and all TD child
 	 * elements have been inserted), or registered if using a DOM source, allowing
@@ -1699,7 +1726,7 @@ DataTable.defaults = {
 		 * However, multiple different tables on the page can use different
 		 * decimal place characters.
 		 *  @type string
-		 *  @default 
+		 *  @default
 		 *
 		 *  @dtopt Language
 		 *  @name DataTable.defaults.language.decimal
@@ -1864,7 +1891,7 @@ DataTable.defaults = {
 		/**
 		 * Assign a `placeholder` attribute to the search `input` element
 		 *  @type string
-		 *  @default 
+		 *  @default
 		 *
 		 *  @dtopt Language
 		 *  @name DataTable.defaults.language.searchPlaceholder
@@ -2067,7 +2094,7 @@ DataTable.defaults = {
 	 * * `full` - 'First', 'Previous', 'Next' and 'Last' buttons
 	 * * `full_numbers` - 'First', 'Previous', 'Next' and 'Last' buttons, plus
 	 *   page numbers
-	 *  
+	 *
 	 * Further methods can be added using {@link DataTable.ext.oPagination}.
 	 *  @type string
 	 *  @default simple_numbers

--- a/js/model/model.settings.js
+++ b/js/model/model.settings.js
@@ -387,6 +387,13 @@ DataTable.models.oSettings = {
 	 */
 	"aoDrawCallback": [],
 
+    /**
+     * Array of callback functions for row created function
+     *  @type array
+     *  @default []
+     */
+    "aoRowPreRowPopulate": [],
+
 	/**
 	 * Array of callback functions for row created function
 	 *  @type array


### PR DESCRIPTION
# problem statement
I source data for a table from a huge array.  This array represents a `Collection` of `Model`s.  When each [`Model`](https://github.com/AmpersandJS/ampersand-model) is instantiated, it become quite a data rich object.  If I instantiate the each Model in the array immediately, the browser will choke when the array is large.  Instead, for performance reasons, if I can mutate the DT row data immediately before column population, I can do mutations (i.e. create my data-rich Models) **just-in-time** and only worry about processing those items that DataTables is rendering!

# solution
mimic `createdRow`'s implentation, as it's purpose is nearly the same, but should be fired *before* the row is populated, not after.

# review
Any docs/etc that may need updating, I am happy to do.  Just give me a boost with some pointers! :+1: 