### PR TITLE
Fix bug: _fnBuildAjax uses ajax as URL even when ajax is object

### DIFF
--- a/js/core/core.ajax.js
+++ b/js/core/core.ajax.js
@@ -111,7 +111,7 @@ function _fnBuildAjax( oSettings, data, fn )
 			oSettings
 		);
 	}
-	else if ( oSettings.sAjaxSource || typeof ajax === 'string' )
+	else if ( ( oSettings.sAjaxSource && !ajax ) || typeof ajax === 'string' )
 	{
 		// DataTables 1.9- compatibility
 		oSettings.jqXHR = $.ajax( $.extend( baseAjax, {


### PR DESCRIPTION
This PR makes sure that ajax is not used as an URL when its type is something else than string. Previously an object was assigned into URL if oSettings.sAjaxSource was true and ajax was an object. That of course caused the URL to be malformed.

This problem occured when I was using [django-datatable-view](https://github.com/pivotal-energy-solutions/django-datatable-view). It might be that it misuses datatables, but it doesn't change the fact that the if fixed in this PR is deficient as far as I see.

I allow the MIT licence terms and so on. So feel free to merge, if this looks ok. :smiley: 
