### PR TITLE
Improve support for html markup in filter and length menu options

### DIFF
--- a/js/core/core.filter.js
+++ b/js/core/core.filter.js
@@ -18,12 +18,14 @@ function _fnFeatureHtmlFilter ( settings )
 	str = str.match(/_INPUT_/) ?
 		str.replace('_INPUT_', input) :
 		str+input;
+	var hasMarkup = !!(str.match(/<([a-z]+)([^<]+)*(?:>(.*)<\/\1>|\s+\/>)/));
+	var content = hasMarkup ? str : $('<label/>').append(str);
 
 	var filter = $('<div/>', {
 			'id': ! features.f ? tableId+'_filter' : null,
 			'class': classes.sFilter
 		} )
-		.append( $('<label/>' ).append( str ) );
+		.append( content );
 
 	var searchFn = function() {
 		/* Update all other filter input elements for the new display */

--- a/js/core/core.length.js
+++ b/js/core/core.length.js
@@ -22,10 +22,11 @@ function _fnFeatureHtmlLength ( settings )
 	var
 		classes  = settings.oClasses,
 		tableId  = settings.sTableId,
-		menu     = settings.aLengthMenu,
-		d2       = $.isArray( menu[0] ),
-		lengths  = d2 ? menu[0] : menu,
-		language = d2 ? menu[1] : menu;
+		layout   = settings.oLanguage.sLengthMenu,
+		entries  = settings.aLengthMenu,
+		d2       = $.isArray( entries[0] ),
+		lengths  = d2 ? entries[0] : entries,
+		language = d2 ? entries[1] : entries;
 
 	var select = $('<select/>', {
 		'name':          tableId+'_length',
@@ -37,13 +38,16 @@ function _fnFeatureHtmlLength ( settings )
 		select[0][ i ] = new Option( language[i], lengths[i] );
 	}
 
-	var div = $('<div><label/></div>').addClass( classes.sLength );
+	var hasMarkup = !!(layout.match(/<([a-z]+)([^<]+)*(?:>(.*)<\/\1>|\s+\/>)/));
+	var div = hasMarkup ? $('<div></div>') : $('<div><label/></div>');
+	div = div.addClass(classes.sLength);
 	if ( ! settings.aanFeatures.l ) {
 		div[0].id = tableId+'_length';
 	}
 
-	div.children().append(
-		settings.oLanguage.sLengthMenu.replace( '_MENU_', select[0].outerHTML )
+	var context = hasMarkup ? div : div.children();
+	context.append(
+		layout.replace( '_MENU_', select[0].outerHTML )
 	);
 
 	// Can't use `select` variable as user might provide their own and the


### PR DESCRIPTION
Adds support for support html markup in `sLengthMenu` and `sSearch`, but without removing labels if html markup is not used. See https://github.com/DataTables/DataTablesSrc/pull/41#issuecomment-95923971.

See regex example here: https://regex101.com/r/vU1sO3/2

Contribution is offered under and will be made available under the project's existing license (MIT).