### PR TITLE
fix for incorrect calculation in _fnBrowserDetect

### DIFF
--- a/js/core/core.compat.js
+++ b/js/core/core.compat.js
@@ -201,7 +201,7 @@ function _fnBrowserDetect( settings )
 	// Scrolling feature / quirks detection
 	var n = $('<div/>')
 		.css( {
-			position: 'absolute',
+			position: 'fixed',
 			top: 0,
 			left: 0,
 			height: 1,


### PR DESCRIPTION
when body's position is changed (left: 375px) _fnBrowserDetect
incorrecly calculates offsets. thus header is a bit misaligned. commit
changes test object's position to fixed. in this case it's position will
be relative to the viewport not to the body.
this fixes [#594](https://github.com/DataTables/DataTables/issues/594)

I agree that the change will be released under the MIT license.