### PR TITLE
Prevent style undefined error

### DIFF
--- a/js/core/core.sizing.js
+++ b/js/core/core.sizing.js
@@ -86,7 +86,9 @@ function _fnCalculateColumnWidths ( oSettings )
 
 		for ( i=0 ; i<visibleColumns.length ; i++ ) {
 			column = columns[ visibleColumns[i] ];
-
+			if ( !headerCells[i] ) {
+		        	continue;
+	                }
 			headerCells[i].style.width = column.sWidthOrig !== null && column.sWidthOrig !== '' ?
 				_fnStringToCss( column.sWidthOrig ) :
 				'';


### PR DESCRIPTION
Throws a style undefined error when it cannot find the header cell, this prevents the error.  This occurs when using ColVis to hide/show certain rows after the page has loaded.

This fork is made under the MIT license and you are free to do as you wish.

