### PR TITLE
TypeError: val is null in for ( var j=0, jLen=val.length ; j<jLen ; j++ )

### DIFF
--- a/js/core/core.data.js
+++ b/js/core/core.data.js
@@ -345,6 +345,11 @@ function _fnSetObjectDataFn( mSource )
 	{
 		/* Like the get, we need to get data from a nested object */
 		var setData = function (data, val, src) {
+			// early return on null values
+			if (val === null)
+			{
+				return;
+			}
 			var a = _fnSplitObjNotation( src ), b;
 			var aLast = a[a.length-1];
 			var arrayNotation, funcNotation, o, innerSrc;

--- a/js/core/core.sizing.js
+++ b/js/core/core.sizing.js
@@ -317,6 +317,10 @@ function _fnStringToCss( s )
 			'0px' :
 			s+'px';
 	}
+	
+	if (typeof s.match == 'undefined') {
+		return null;
+	}
 
 	// Check it has a unit character already
 	return s.match(/\d$/) ?


### PR DESCRIPTION
The function `-api _fnSetObjectDataFn( mSource )` returns a function that can be used to set data from a source object, nevertheless it doesn't handle correctly the case when the value is null `(val === null)`, which is a legitimate value. This can cause problems for function relaying on this function. One example is when Editor use this function to set the values `-api Editor.prototype._submit`, if a user didn't select anything in a multiple value select, the value for this field is null. A very simple way (but probably not the most elegant) to solve this one is by ignoring a null value passed an early returning.