### PR TITLE
Preventing re-sort and re-filter when updating data

### DIFF
--- a/js/api/api.draw.js
+++ b/js/api/api.draw.js
@@ -8,6 +8,11 @@ _api_register( 'draw()', function ( paging ) {
 		if ( paging === 'page' ) {
 			_fnDraw( settings );
 		}
+		// To update the data without re-sorting, re-filtering, or changing the page, the hold-order option was added.
+		// This sets the ignoreSortAndFilter falg on _fnReDraw.
+		else if (paging === 'hold-order') {
+					_fnReDraw(settings, true, true);
+		}
 		else {
 			if ( typeof paging === 'string' ) {
 				paging = paging === 'full-hold' ?

--- a/js/core/core.draw.js
+++ b/js/core/core.draw.js
@@ -449,14 +449,16 @@ function _fnDraw( oSettings )
  *  @param {object} oSettings dataTables settings object
  *  @param {boolean} [holdPosition] Keep the current paging position. By default
  *    the paging is reset to the first page
+ *  @param {boolean} [ignoreSortAndFilter] Keep the rows as they are rather than
+ *    resorting and filtering based on the table settings
  *  @memberof DataTable#oApi
  */
-function _fnReDraw( settings, holdPosition )
+function _fnReDraw( settings, holdPosition, ignoreSortAndFilter )
 {
 	var
 		features = settings.oFeatures,
-		sort     = features.bSort,
-		filter   = features.bFilter;
+		sort     = ignoreSortAndFilter === true ? false : features.bSort,
+		filter   = ignoreSortAndFilter === true ? false : features.bFilter;
 
 	if ( sort ) {
 		_fnSort( settings );


### PR DESCRIPTION
We have as use case where users are working through a list of items in a table.  They may have applied a filter and/or sort to the table.  As they work through the list changes they make can be to values used for sorting or filtering.

We want the changes to appear in the table but we don't want them to loose their place in the list.

To Address this we added a "hold-order" option to draw() which in turn enables a ignoreSortAndFilter flag on _fnReDraw().  This disables sorting and filtering therefore achieving the desired effect.

I don't know how useful this would be to others but I thought I'd contribute it.
