### PR TITLE
Added check to ensure the sorting column exists

### DIFF
--- a/js/core/core.sort.js
+++ b/js/core/core.sort.js
@@ -41,7 +41,7 @@ function _fnSortFlatten ( settings )
 	for ( i=0 ; i<nestedSort.length ; i++ )
 	{
 		srcCol = nestedSort[i][0];
-		aDataSort = aoColumns[ srcCol ].aDataSort;
+		aDataSort = aoColumns[ srcCol ] ? aoColumns[ srcCol ].aDataSort : [];
 
 		for ( k=0, kLen=aDataSort.length ; k<kLen ; k++ )
 		{


### PR DESCRIPTION
Attempting to not have a default sort causes an issue where it assumes there will always be a sort column. My pull request fixes this issue.
Example site: http://0xbrock.github.io/DataTablesSrc/
From FireBug: 
TypeError: aoColumns[srcCol] is undefined
aDataSort = aoColumns[ srcCol ].aDataSort;

From Chrome:
Uncaught TypeError: Cannot read property 'aDataSort' of undefined