### PR TITLE
enable js createlement in render function

### DIFF
--- a/js/core/core.draw.js
+++ b/js/core/core.draw.js
@@ -48,7 +48,14 @@ function _fnCreateTr ( oSettings, iRow, nTrIn, anTds )
 			// Need to create the HTML if new, or if a rendering function is defined
 			if ( !nTrIn || oCol.mRender || oCol.mData !== i )
 			{
-				nTd.innerHTML = _fnGetCellData( oSettings, iRow, i, 'display' );
+			   	var cellData = _fnGetCellData(oSettings, iRow, i, 'display');
+			   	// if the render function of columns creates directly a dom object
+                    		if (typeof cellData === 'object')
+                    		{
+                        		nTd.appendChild(cellData);
+		                }
+                    		else
+                    		{ nTd.innerHTML = cellData; }
 			}
 
 			/* Add user defined class */


### PR DESCRIPTION
this change allows to make this ( the click event in particular)

// extract from the datatable column definition in full js
 {
              title: "accès bureau de prescription",
              render: function (data, type, row, meta)
              {
                  return $('<div/>', {
                      text: "Presc. V5",
                      class: 'ouvrirPrescV5'  
                  })
                .click(function () {  lancerBureau(row); })[0];
              }
          },

i think that the click event should be chained and not triggered with a new selector on tbody which to recreate the data() object.

so i can make it work like that but i think that it's not logical /or/ the most efficient way
  .on('click', 'tbody .ouvrirPrescV5', function () {

```
     var dt = monTableau.row($(this).parents('tr')).data();
     lancerBureau(dt);
  });
```

//the idea is to full manage the contenent of the cell including events
// if you have another way to do such, this change is useless but as i see that the innerHTML is used to insert content in td i think that only dom strings are accepted and not dom objects.
