### PR TITLE
Fix bug in keyboard navigation where the back button loses focus on press of enter key

### DIFF
--- a/js/ext/ext.paging.js
+++ b/js/ext/ext.paging.js
@@ -166,7 +166,7 @@ $.extend( true, DataTable.ext.renderer, {
 
 			attach( $(host).empty(), buttons );
 
-			if ( activeEl ) {
+			if ( activeEl !== undefined ) {
 				$(host).find( '[data-dt-idx='+activeEl+']' ).focus();
 			}
 		}


### PR DESCRIPTION
There is a bug that exists when navigating to the back button on
the keyboard and pressing enter. Since the back button is the 0th element, the 
if statement evaluates to false, therefore not properly giving focus back.