### PR TITLE
saveState: correction to documentation, and new example

### DIFF
--- a/docs/option/stateSave.xml
+++ b/docs/option/stateSave.xml
@@ -8,11 +8,11 @@
 	<default value="false" />
 
 	<description>
-		Enable or disable state saving. When enabled aDataTables will storage state information such as pagination position, display length, filtering and sorting. When the end user reloads the page the table's state will be altered to match what they had previously set up.
+		Enable or disable state saving. When enabled aDataTables will store state information such as pagination position, display length, filtering and sorting. When the end user reloads the page the table's state will be altered to match what they had previously set up.
 
 		Data storage for the state information in the browser is performed by use of the `localStorage` or `sessionStorage` HTML5 APIs. The `dt-init stateDuration` indicated to DataTables which API should be used (`localStorage`: 0 or greater, or `sessionStorage`: -1).
 
-		Information is stored using the table's DOM `id` to be able to uniquely identify each table's state data. If the table's `id` changes the state information will be lost.
+		To be able to uniquely identify each table's state data, information is stored using a combination of the table's DOM `id` and the current page's pathname.  If the table's `id` changes, or the page URL changes, the state information will be lost.
 
 		Please note that the use of the HTML5 APIs for data storage means that the built in state saving option **will not work with IE6/7** as these browsers do not support these APIs. Alternative options of using cookies or saving the state on the server through Ajax can be used through the `dt-init stateSaveCallback` and `dt-init stateLoadCallback` options.
 	</description>
@@ -20,6 +20,18 @@
 	<example title="Enable state saving"><![CDATA[
 $('#example').dataTable( {
   stateSave: true
+} );
+]]></example>
+
+	<example title="Enable state saving and override state save/load handlers to use only the table's DOM id"><![CDATA[
+$('#example').dataTable( {
+  stateSave: true,
+  stateSaveCallback: function(settings,data) {
+      localStorage.setItem( 'DataTables_' + settings.sInstance, JSON.stringify(data) )
+    },
+  stateLoadCallback: function(settings) {
+    return JSON.parse( localStorage.getItem( 'DataTables_' + settings.sInstance ) )
+    }
 } );
 ]]></example>
 


### PR DESCRIPTION
I can see why there are issues about unpredictable behaviour of saveState.  The documentation says that state is saved only against the table's DOM id but the code silently extends this id with the current page pathname.

So by default in an app that uses a REST-style path scheme the state is saved for e.g. "/view/group/10" but is not available for "/view/group/11".

This PR clarifies the documentation and adds an example which shows how to save and load localStorage against the DOM id-only; which may be more appropriate for some REST-style apps.

This contribution and any further contributions by myself (frank.carnovale@gmail.com) is offered under and will be made available under the DataTable project's existing license (MIT).
