### PR TITLE
Check if index of aoColumns resolves to an object

### DIFF
--- a/js/core/core.scrolling.js
+++ b/js/core/core.scrolling.js
@@ -229,7 +229,8 @@ function _fnScrollDraw ( settings )
 
 	$.each( _fnGetUniqueThs( settings, headerCopy ), function ( i, el ) {
 		idx = _fnVisibleToColumnIndex( settings, i );
-		el.style.width = settings.aoColumns[idx].sWidth;
+		if(settings.aoColumns[idx])
+			el.style.width = settings.aoColumns[idx].sWidth;
 	} );
 
 	if ( footer ) {


### PR DESCRIPTION
I was getting an exception with scrollX enabled here because the index doesnt resolve to an object.
I think it could be because I am adding another row to the header to contain per-column search boxes.
