### PR TITLE
Update dataTables.semanticui.scss

### DIFF
--- a/css/dataTables.semanticui.scss
+++ b/css/dataTables.semanticui.scss
@@ -40,7 +40,6 @@ table.dataTable.table {
 	td,
 	th {
 		-webkit-box-sizing: content-box;
-		-moz-box-sizing: content-box;
 		box-sizing: content-box;
 
 		&.dataTables_empty {


### PR DESCRIPTION
Remove prefixed -moz-box-sizing (not needed since ff 29)
https://developer.mozilla.org/en-US/Firefox/Releases/29
