### PR TITLE
Update jquery.dataTables.scss

### DIFF
--- a/css/jquery.dataTables.scss
+++ b/css/jquery.dataTables.scss
@@ -392,7 +392,6 @@ table.dataTable,
 table.dataTable th,
 table.dataTable td {
 	-webkit-box-sizing: content-box;
-	   -moz-box-sizing: content-box;
 	        box-sizing: content-box;
 }
 


### PR DESCRIPTION
Remove prefixed -moz-box-sizing (not needed since ff 29)
https://developer.mozilla.org/en-US/Firefox/Releases/29