### PR TITLE
Update dataTables.foundation.scss

### DIFF
--- a/css/dataTables.foundation.scss
+++ b/css/dataTables.foundation.scss
@@ -8,7 +8,6 @@ table.dataTable {
 	td,
 	th {
 		-webkit-box-sizing: content-box;
-		-moz-box-sizing: content-box;
 		box-sizing: content-box;
 
 		&.dataTables_empty {


### PR DESCRIPTION
Remove prefixed -moz-box-sizing (not needed since ff 29)
https://developer.mozilla.org/en-US/Firefox/Releases/29