### PR TITLE
Update dataTables.bootstrap4.scss

### DIFF
--- a/css/dataTables.bootstrap4.scss
+++ b/css/dataTables.bootstrap4.scss
@@ -9,7 +9,6 @@ table.dataTable {
 	td,
 	th {
 		-webkit-box-sizing: content-box;
-		-moz-box-sizing: content-box;
 		box-sizing: content-box;
 
 		&.dataTables_empty {


### PR DESCRIPTION
Remove prefixed -moz-box-sizing (not needed since ff 29)
https://developer.mozilla.org/en-US/Firefox/Releases/29