### PR TITLE
Fix: Bootstrap 4 flexbox grid

### DIFF
--- a/js/integration/dataTables.bootstrap4.js
+++ b/js/integration/dataTables.bootstrap4.js
@@ -46,9 +46,9 @@ var DataTable = $.fn.dataTable;
 /* Set the defaults for DataTables initialisation */
 $.extend( true, DataTable.defaults, {
 	dom:
-		"<'row'<'col-md-6'l><'col-md-6'f>>" +
-		"<'row'<'col-md-12'tr>>" +
-		"<'row'<'col-md-5'i><'col-md-7'p>>",
+		"<'row'<'col-xs-12 col-md-6'l><'col-xs-12 col-md-6'f>>" +
+		"<'row'<'col-xs-12'tr>>" +
+		"<'row'<'col-xs-12 col-md-5'i><'col-xs-12 col-md-7'p>>",
 	renderer: 'bootstrap'
 } );
 


### PR DESCRIPTION
The flexbox enabled grid in bootstap 4 requires the lowest `.col-` to be set. https://github.com/twbs/bootstrap/issues/17603#issuecomment-180862254
