### PR TITLE
Fix PHP warnings

### DIFF
--- a/build/lib/DT_Markdown.php
+++ b/build/lib/DT_Markdown.php
@@ -53,7 +53,7 @@ class DT_Markdown_Parser extends MarkdownExtraExtended_Parser {
 	}
 
 
-	function DT_Markdown_Parser( $options )
+	function __construct( $options )
 	{
 		if ( isset( $options['nohtml'] ) ) {
 			$this->no_markup = $options['nohtml'];
@@ -63,7 +63,7 @@ class DT_Markdown_Parser extends MarkdownExtraExtended_Parser {
 		$this->block_gamut['doColumns'] = 13;
 		$this->block_gamut['doGrid'] = 12;
 		$this->block_gamut['doPullQuotes'] = 61;
-		parent::MarkdownExtra_Parser();
+		MarkdownExtra_Parser::__construct();
 	}
 
 

--- a/build/lib/markdown.php
+++ b/build/lib/markdown.php
@@ -239,7 +239,7 @@ class Markdown_Parser {
 	var $predef_titles = array();
 
 
-	function Markdown_Parser() {
+	function __construct() {
 	#
 	# Constructor function. Initialize appropriate member variables.
 	#
@@ -1697,7 +1697,7 @@ class MarkdownExtra_Parser extends Markdown_Parser {
 	var $predef_abbr = array();
 
 
-	function MarkdownExtra_Parser() {
+	function __construct() {
 	#
 	# Constructor function. Initialize the parser object.
 	#
@@ -1723,7 +1723,7 @@ class MarkdownExtra_Parser extends Markdown_Parser {
 			"doAbbreviations"    => 70,
 			);
 		
-		parent::Markdown_Parser();
+		parent::__construct();
 	}
 	
 	

--- a/build/lib/markdown_extended.php
+++ b/build/lib/markdown_extended.php
@@ -12,14 +12,12 @@ class MarkdownExtraExtended_Parser extends MarkdownExtra_Parser {
 	var $block_tags_re = 'figure|figcaption|p|div|h[1-6]|blockquote|pre|table|dl|ol|ul|address|form|fieldset|iframe|hr|legend';
 	var $default_classes;
 		
-	function MarkdownExtraExtended_Parser($default_classes = array()) {
-	    $default_classes = $default_classes;
-		
+	function __construct($default_classes = array()) {
 		$this->block_gamut += array(
 			"doFencedFigures" => 7,
 		);
-		
-		parent::MarkdownExtra_Parser();
+
+		MarkdownExtra_Parser::__construct();
 	}
 	
 	function transform($text) {	


### PR DESCRIPTION
PHP has moved away from the practice of mirroring constructor names with the class name. This quells a lot of angry warnings for people trying to build with a more recent version of PHP, but doesn't break 5.4, which is the current build dependency.