### PR TITLE
Fix date sorting of empty fields

### DIFF
--- a/js/ext/ext.sorting.js
+++ b/js/ext/ext.sorting.js
@@ -69,7 +69,7 @@ function _addNumericSort ( decimalPlace ) {
 $.extend( _ext.type.order, {
 	// Dates
 	"date-pre": function ( d ) {
-		return Date.parse( d ) || 0;
+		return Date.parse( d ) || -Infinity;
 	},
 
 	// html


### PR DESCRIPTION
Previously, date sorting of values that
failed to parse as a date were sorted as
if they were 1970-01-01 (Unix and JS epoch).

Now, they sort before other dates.

Example: https://jsfiddle.net/qae6zjty/1/

I acknowledge that my contribution is offered under and will be made available under the MIT license.