### PR TITLE
Allow templating in sortAscending and sortDescending ARIA strings

### DIFF
--- a/docs/option/language.aria.sortAscending.xml
+++ b/docs/option/language.aria.sortAscending.xml
@@ -10,14 +10,14 @@
 	<description>
 		ARIA label that is added to the table headers when the column may be sorted ascending by activating the column (click or return when focused).
 
-		Note that the column header text is prefixed to this string. 
+		The variable _HEADER_ is replaced by the column header. If not present, the column header is prefixed to this string.
 	</description>
 
 	<example title="Set ARIA sort ascending string"><![CDATA[
 $('#example').dataTable( {
   "language": {
     "aria": {
-      "sortAscending": " - click/return to sort ascending"
+      "sortAscending": "click to sort by _HEADER_ ascending"
     }
   }
 } );

--- a/docs/option/language.aria.sortDescending.xml
+++ b/docs/option/language.aria.sortDescending.xml
@@ -10,14 +10,14 @@
 	<description>
 		ARIA label that is added to the table headers when the column may be  sorted descending by activing the column (click or return when focused).
 
-		Note that the column header text is prefixed to this string. 
+		The variable _HEADER_ is replaced by the column header. If not present, the column header is prefixed to this string.
 	</description>
 
 	<example title="Set ARIA sort descending string"><![CDATA[
 $('#example').dataTable( {
   "language": {
     "aria": {
-       "sortDescending": " - click/return to sort descending"
+       "sortDescending": "click to sort by _HEADER_ descending"
     }
   }
 } );

--- a/js/core/core.sort.js
+++ b/js/core/core.sort.js
@@ -229,10 +229,14 @@ function _fnSortAria ( settings )
 				nextSort = asSorting[0];
 			}
 
-			label = sTitle + ( nextSort === "asc" ?
-				oAria.sSortAscending :
-				oAria.sSortDescending
-			);
+			var sSortLabel = nextSort === "asc" ? oAria.sSortAscending : oAria.sSortDescending;
+
+			if (sSortLabel.indexOf("_HEADER_") !== -1) {
+				label = sSortLabel.replace("_HEADER_", sTitle);
+			}
+			else {
+				label = sTitle + sSortLabel;
+			}
 		}
 		else {
 			label = sTitle;

--- a/js/model/model.defaults.js
+++ b/js/model/model.defaults.js
@@ -1417,9 +1417,10 @@ DataTable.defaults = {
 			/**
 			 * ARIA label that is added to the table headers when the column may be
 			 * sorted ascending by activing the column (click or return when focused).
-			 * Note that the column header is prefixed to this string.
+			 * The variable _HEADER_ is replaced by the column header. If not present,
+			 * the column header is prefixed to this string.
 			 *  @type string
-			 *  @default : activate to sort column ascending
+			 *  @default _HEADER_: activate to sort column ascending
 			 *
 			 *  @dtopt Language
 			 *  @name DataTable.defaults.language.aria.sortAscending
@@ -1429,20 +1430,21 @@ DataTable.defaults = {
 			 *      $('#example').dataTable( {
 			 *        "language": {
 			 *          "aria": {
-			 *            "sortAscending": " - click/return to sort ascending"
+			 *            "sortAscending": "click to sort by _HEADER_ ascending"
 			 *          }
 			 *        }
 			 *      } );
 			 *    } );
 			 */
-			"sSortAscending": ": activate to sort column ascending",
+			"sSortAscending": "_HEADER_: activate to sort column ascending",
 
 			/**
 			 * ARIA label that is added to the table headers when the column may be
 			 * sorted descending by activing the column (click or return when focused).
-			 * Note that the column header is prefixed to this string.
+			 * The variable _HEADER_ is replaced by the column header. If not present,
+			 * the column header is prefixed to this string.
 			 *  @type string
-			 *  @default : activate to sort column ascending
+			 *  @default _HEADER_: activate to sort column ascending
 			 *
 			 *  @dtopt Language
 			 *  @name DataTable.defaults.language.aria.sortDescending
@@ -1452,13 +1454,13 @@ DataTable.defaults = {
 			 *      $('#example').dataTable( {
 			 *        "language": {
 			 *          "aria": {
-			 *            "sortDescending": " - click/return to sort descending"
+			 *            "sortDescending": "click to sort by _HEADER_ descending"
 			 *          }
 			 *        }
 			 *      } );
 			 *    } );
 			 */
-			"sSortDescending": ": activate to sort column descending"
+			"sSortDescending": "_HEADER_: activate to sort column descending"
 		},
 
 		/**


### PR DESCRIPTION
ARIA labels for sortable columns are built using raw string concatenation. With this pull request, the same string templating that works in other components (like in pagination: `Showing page _PAGE_ of _PAGES_`) can be used for both of these strings.

I offer this contribution under the same license the project uses, the MIT license.
