### PR TITLE
Update documentation to reflect that there are 6 built in paging options now, not 4

### DIFF
--- a/docs/option/pagingType.xml
+++ b/docs/option/pagingType.xml
@@ -11,7 +11,7 @@
     <![CDATA[
     The pagination option of DataTables will display a pagination control below the table (by default, its position can be changed using `dt-init dom` and CSS) with buttons that the end user can use to navigate the pages of the table. Which buttons are shown in the pagination control are defined by the option given here.
 
-    DataTables has four built-in paging button arrangements:
+    DataTables has six built-in paging button arrangements:
     
     * `string numbers` - Page number buttons only (<span class="since">1.10.8</span>)
     * `string simple` - 'Previous' and 'Next' buttons only

--- a/examples/basic_init/alt_pagination.xml
+++ b/examples/basic_init/alt_pagination.xml
@@ -18,7 +18,7 @@ $(document).ready(function() {
 
 The default page control presented by DataTables (forward and backward buttons with up to 7 page numbers in-between) is fine for most situations, but there are cases where you may wish to customise the options presented to the end user. This is done through DataTables' extensible pagination mechanism, the `dt-init pagingType` option.
 
-There are four built-in options for which pagination controls DataTables should show:
+There are six built-in options for which pagination controls DataTables should show:
 
 * `string numbers` - Page number buttons only
 * `string simple` - 'Previous' and 'Next' buttons only

--- a/js/model/model.defaults.js
+++ b/js/model/model.defaults.js
@@ -2054,9 +2054,10 @@ DataTable.defaults = {
 
 
 	/**
-	 * DataTables features four different built-in options for the buttons to
+	 * DataTables features six different built-in options for the buttons to
 	 * display for pagination control:
 	 *
+	 * * `numbers` - Page number buttons only
 	 * * `simple` - 'Previous' and 'Next' buttons only
 	 * * 'simple_numbers` - 'Previous' and 'Next' buttons, plus page numbers
 	 * * `full` - 'First', 'Previous', 'Next' and 'Last' buttons


### PR DESCRIPTION
After adding the first_last_numbers pagination option, I found some documentation that needs to be updated. I don't know if I found all the places, but this is definitely a start. As you can see, this wasn't even updated when the fifth option was added.