### PR TITLE
Force research when regex is active

### DIFF
--- a/js/core/core.filter.js
+++ b/js/core/core.filter.js
@@ -240,6 +240,7 @@ function _fnFilter( settings, input, force, regex, smart, caseInsensitive )
 		// New search - start from the master array
 		if ( invalidated ||
 			 force ||
+			 regex ||
 			 prevSearch.length > input.length ||
 			 input.indexOf(prevSearch) !== 0 ||
 			 settings.bSorted // On resort, the display master needs to be


### PR DESCRIPTION
The problem is that when using regex and querying something like "item1|item2", only item1 is actually filtered, as the filter is always applied against the already filtered data. To ensure that the "or"ed query is properly applied, one possibility is to remove the last character and add it again (the "prevSearch.length > input.length" condition fires).

This fix forces a new search against the master array when regex is set to true, so that such "or"ed queries will behave as expected.