### PR TITLE
Restricted CSS rules for .dataTables_scrollXXX

### DIFF
--- a/css/dataTables.bootstrap.scss
+++ b/css/dataTables.bootstrap.scss
@@ -146,12 +146,12 @@ div.dataTables_scrollHead table.dataTable {
 }
 
 div.dataTables_scrollBody {
-	table {
+	> table {
 		border-top: none;
 		margin-top: 0 !important;
 		margin-bottom: 0 !important;
 
-		thead { // Hide sort icons
+		> thead { // Hide sort icons
 			.sorting:after,
 			.sorting_asc:after,
 			.sorting_desc:after {
@@ -159,14 +159,14 @@ div.dataTables_scrollBody {
 			}
 		}
 
-		tbody tr:first-child th,
-		tbody tr:first-child td {
+		> tbody > tr:first-child > th,
+		> tbody > tr:first-child > td {
 			border-top: none;
 		}
 	}
 }
 
-div.dataTables_scrollFoot table {
+div.dataTables_scrollFoot > table {
 	margin-top: 0 !important;
 	border-top: none;
 }

--- a/css/jquery.dataTables.scss
+++ b/css/jquery.dataTables.scss
@@ -530,19 +530,21 @@ table.dataTable td {
 			*margin-top: -1px;
 			-webkit-overflow-scrolling: touch;
 
-			th, td {
-				// Setting v-align baseline can cause the headers to be visible
-				vertical-align: middle;
-			}
+			> table > thead > tr, > table > tbody > tr {
+				> th, > td {
+					// Setting v-align baseline can cause the headers to be visible
+					vertical-align: middle;
+				}
 
-			th > div.dataTables_sizing,
-			td > div.dataTables_sizing {
-				// Hide the element used to wrap the content in the header for
-				// the body scrolling table
-				height: 0;
-				overflow: hidden;
-				margin: 0 !important;
-				padding: 0 !important;
+				> th > div.dataTables_sizing,
+				> td > div.dataTables_sizing {
+					// Hide the element used to wrap the content in the header for
+					// the body scrolling table
+					height: 0;
+					overflow: hidden;
+					margin: 0 !important;
+					padding: 0 !important;
+				}
 			}
 		}
 	}
@@ -552,8 +554,8 @@ table.dataTable td {
 			border-bottom: $table-header-border;
 		}
 
-		div.dataTables_scrollHead table,
-		div.dataTables_scrollBody table {
+		div.dataTables_scrollHead > table,
+		div.dataTables_scrollBody > table {
 			border-bottom: none;
 		}
 	}


### PR DESCRIPTION
CSS rules for scrollable data-table should not affect nested tables.

I changed only dataTables.bootstrap.css and jquery.dataTables.css (because of lack of time).