### PR TITLE
Additional Updates for Bootstrap 4 Alpha 6

### DIFF
--- a/js/integration/dataTables.bootstrap4.js
+++ b/js/integration/dataTables.bootstrap4.js
@@ -58,7 +58,7 @@ $.extend( DataTable.ext.classes, {
 	sWrapper:      "dataTables_wrapper container-fluid dt-bootstrap4",
 	sFilterInput:  "form-control form-control-sm",
 	sLengthSelect: "form-control form-control-sm",
-	sProcessing:   "dataTables_processing card bg-faded",
+	sProcessing:   "dataTables_processing card",
 	sPageButton:   "paginate_button page-item"
 } );
 

--- a/js/integration/dataTables.bootstrap4.js
+++ b/js/integration/dataTables.bootstrap4.js
@@ -56,9 +56,9 @@ $.extend( true, DataTable.defaults, {
 /* Default class modification */
 $.extend( DataTable.ext.classes, {
 	sWrapper:      "dataTables_wrapper container-fluid dt-bootstrap4",
-	sFilterInput:  "form-control input-sm",
-	sLengthSelect: "form-control input-sm",
-	sProcessing:   "dataTables_processing panel panel-default",
+	sFilterInput:  "form-control form-control-sm",
+	sLengthSelect: "form-control form-control-sm",
+	sProcessing:   "dataTables_processing card bg-faded",
 	sPageButton:   "paginate_button page-item"
 } );
 


### PR DESCRIPTION
There are a couple of additional changes required for Bootstrap 4 Alpha 6 compatibility.

To adjust the size of form inputs, form-control-_xx_ has replaced input-_xx_.

https://v4-alpha.getbootstrap.com/components/forms/#control-sizing


Panel has been removed and replaced with the new Bootstrap component, card.

https://v4-alpha.getbootstrap.com/components/card/
