### PR TITLE
Let me explain our application and why we need this feature.

### DIFF
--- a/js/DataTables.js
+++ b/js/DataTables.js
@@ -25,384 +25,387 @@
 /*globals $,require,jQuery,define,_selector_run,_selector_opts,_selector_first,_selector_row_indexes,_ext,_Api,_api_register,_api_registerPlural,_re_new_lines,_re_html,_re_formatted_numeric,_re_escape_regex,_empty,_intVal,_numToDecimal,_isNumber,_isHtml,_htmlNumeric,_pluck,_pluck_order,_range,_stripHtml,_unique,_fnBuildAjax,_fnAjaxUpdate,_fnAjaxParameters,_fnAjaxUpdateDraw,_fnAjaxDataSrc,_fnAddColumn,_fnColumnOptions,_fnAdjustColumnSizing,_fnVisibleToColumnIndex,_fnColumnIndexToVisible,_fnVisbleColumns,_fnGetColumns,_fnColumnTypes,_fnApplyColumnDefs,_fnHungarianMap,_fnCamelToHungarian,_fnLanguageCompat,_fnBrowserDetect,_fnAddData,_fnAddTr,_fnNodeToDataIndex,_fnNodeToColumnIndex,_fnGetCellData,_fnSetCellData,_fnSplitObjNotation,_fnGetObjectDataFn,_fnSetObjectDataFn,_fnGetDataMaster,_fnClearTable,_fnDeleteIndex,_fnInvalidate,_fnGetRowElements,_fnCreateTr,_fnBuildHead,_fnDrawHead,_fnDraw,_fnReDraw,_fnAddOptionsHtml,_fnDetectHeader,_fnGetUniqueThs,_fnFeatureHtmlFilter,_fnFilterComplete,_fnFilterCustom,_fnFilterColumn,_fnFilter,_fnFilterCreateSearch,_fnEscapeRegex,_fnFilterData,_fnFeatureHtmlInfo,_fnUpdateInfo,_fnInfoMacros,_fnInitialise,_fnInitComplete,_fnLengthChange,_fnFeatureHtmlLength,_fnFeatureHtmlPaginate,_fnPageChange,_fnFeatureHtmlProcessing,_fnProcessingDisplay,_fnFeatureHtmlTable,_fnScrollDraw,_fnApplyToChildren,_fnCalculateColumnWidths,_fnThrottle,_fnConvertToWidth,_fnGetWidestNode,_fnGetMaxLenString,_fnStringToCss,_fnSortFlatten,_fnSort,_fnSortAria,_fnSortListener,_fnSortAttachListener,_fnSortingClasses,_fnSortData,_fnSaveState,_fnLoadState,_fnSettingsFromNode,_fnLog,_fnMap,_fnBindAction,_fnCallbackReg,_fnCallbackFire,_fnLengthOverflow,_fnRenderer,_fnDataSource,_fnRowAttributes*/
 
 (function( factory ) {
-	"use strict";
+    "use strict";
 
-	if ( typeof define === 'function' && define.amd ) {
-		// AMD
-		define( ['jquery'], function ( $ ) {
-			return factory( $, window, document );
-		} );
-	}
-	else if ( typeof exports === 'object' ) {
-		// CommonJS
-		module.exports = function (root, $) {
-			if ( ! root ) {
-				// CommonJS environments without a window global must pass a
-				// root. This will give an error otherwise
-				root = window;
-			}
+    if ( typeof define === 'function' && define.amd ) {
+        // AMD
+        define( ['jquery'], function ( $ ) {
+            return factory( $, window, document );
+        } );
+    }
+    else if ( typeof exports === 'object' ) {
+        // CommonJS
+        module.exports = function (root, $) {
+            if ( ! root ) {
+                // CommonJS environments without a window global must pass a
+                // root. This will give an error otherwise
+                root = window;
+            }
 
-			if ( ! $ ) {
-				$ = typeof window !== 'undefined' ? // jQuery's factory checks for a global window
-					require('jquery') :
-					require('jquery')( root );
-			}
+            if ( ! $ ) {
+                $ = typeof window !== 'undefined' ? // jQuery's factory checks for a global window
+                    require('jquery') :
+                    require('jquery')( root );
+            }
 
-			return factory( $, root, root.document );
-		};
-	}
-	else {
-		// Browser
-		factory( jQuery, window, document );
-	}
+            return factory( $, root, root.document );
+        };
+    }
+    else {
+        // Browser
+        factory( jQuery, window, document );
+    }
 }
 (function( $, window, document, undefined ) {
-	"use strict";
+    "use strict";
 
-	/**
-	 * DataTables is a plug-in for the jQuery Javascript library. It is a highly
-	 * flexible tool, based upon the foundations of progressive enhancement,
-	 * which will add advanced interaction controls to any HTML table. For a
-	 * full list of features please refer to
-	 * [DataTables.net](href="http://datatables.net).
-	 *
-	 * Note that the `DataTable` object is not a global variable but is aliased
-	 * to `jQuery.fn.DataTable` and `jQuery.fn.dataTable` through which it may
-	 * be  accessed.
-	 *
-	 *  @class
-	 *  @param {object} [init={}] Configuration object for DataTables. Options
-	 *    are defined by {@link DataTable.defaults}
-	 *  @requires jQuery 1.7+
-	 *
-	 *  @example
-	 *    // Basic initialisation
-	 *    $(document).ready( function {
+    /**
+     * DataTables is a plug-in for the jQuery Javascript library. It is a highly
+     * flexible tool, based upon the foundations of progressive enhancement,
+     * which will add advanced interaction controls to any HTML table. For a
+     * full list of features please refer to
+     * [DataTables.net](href="http://datatables.net).
+     *
+     * Note that the `DataTable` object is not a global variable but is aliased
+     * to `jQuery.fn.DataTable` and `jQuery.fn.dataTable` through which it may
+     * be  accessed.
+     *
+     *  @class
+     *  @param {object} [init={}] Configuration object for DataTables. Options
+     *    are defined by {@link DataTable.defaults}
+     *  @requires jQuery 1.7+
+     *
+     *  @example
+     *    // Basic initialisation
+     *    $(document).ready( function {
 	 *      $('#example').dataTable();
 	 *    } );
-	 *
-	 *  @example
-	 *    // Initialisation with configuration options - in this case, disable
-	 *    // pagination and sorting.
-	 *    $(document).ready( function {
+     *
+     *  @example
+     *    // Initialisation with configuration options - in this case, disable
+     *    // pagination and sorting.
+     *    $(document).ready( function {
 	 *      $('#example').dataTable( {
 	 *        "paginate": false,
 	 *        "sort": false
 	 *      } );
 	 *    } );
-	 */
-	var DataTable = function ( options )
-	{
-		_buildInclude('api.legacy.js');
+     */
+    var DataTable = function ( options )
+    {
+        _buildInclude('api.legacy.js');
 
-		var _that = this;
-		var emptyInit = options === undefined;
-		var len = this.length;
+        var _that = this;
+        var emptyInit = options === undefined;
+        var len = this.length;
 
-		if ( emptyInit ) {
-			options = {};
-		}
+        if ( emptyInit ) {
+            options = {};
+        }
 
-		this.oApi = this.internal = _ext.internal;
+        this.oApi = this.internal = _ext.internal;
 
-		// Extend with old style plug-in API methods
-		for ( var fn in DataTable.ext.internal ) {
-			if ( fn ) {
-				this[fn] = _fnExternApiFunc(fn);
-			}
-		}
+        // Extend with old style plug-in API methods
+        for ( var fn in DataTable.ext.internal ) {
+            if ( fn ) {
+                this[fn] = _fnExternApiFunc(fn);
+            }
+        }
 
-		this.each(function() {
-			// For each initialisation we want to give it a clean initialisation
-			// object that can be bashed around
-			var o = {};
-			var oInit = len > 1 ? // optimisation for single table case
-				_fnExtend( o, options, true ) :
-				options;
+        this.each(function() {
+            // For each initialisation we want to give it a clean initialisation
+            // object that can be bashed around
+            var o = {};
+            var oInit = len > 1 ? // optimisation for single table case
+                _fnExtend( o, options, true ) :
+                options;
 
-			_buildInclude('core.constructor.js');
-		} );
-		_that = null;
-		return this;
-	};
+            _buildInclude('core.constructor.js');
+        } );
+        _that = null;
+        return this;
+    };
 
-	_buildInclude('core.internal.js');
-	_buildInclude('api.util.js');
-	_buildInclude('core.compat.js');
-	_buildInclude('core.columns.js');
-	_buildInclude('core.data.js');
-	_buildInclude('core.draw.js');
-	_buildInclude('core.ajax.js');
-	_buildInclude('core.filter.js');
-	_buildInclude('core.info.js');
-	_buildInclude('core.init.js');
-	_buildInclude('core.length.js');
-	_buildInclude('core.page.js');
-	_buildInclude('core.processing.js');
-	_buildInclude('core.scrolling.js');
-	_buildInclude('core.sizing.js');
-	_buildInclude('core.sort.js');
-	_buildInclude('core.state.js');
-	_buildInclude('core.support.js');
+    _buildInclude('core.internal.js');
+    _buildInclude('api.util.js');
+    _buildInclude('core.compat.js');
+    _buildInclude('core.columns.js');
+    _buildInclude('core.data.js');
+    _buildInclude('core.exclude.js');
+    _buildInclude('core.draw.js');
+    _buildInclude('core.ajax.js');
+    _buildInclude('core.filter.js');
+    _buildInclude('core.info.js');
+    _buildInclude('core.init.js');
+    _buildInclude('core.length.js');
+    _buildInclude('core.page.js');
+    _buildInclude('core.processing.js');
+    _buildInclude('core.scrolling.js');
+    _buildInclude('core.sizing.js');
+    _buildInclude('core.sort.js');
+    _buildInclude('core.state.js');
+    _buildInclude('core.support.js');
 
-	_buildInclude('api.base.js');
-	_buildInclude('api.table.js');
-	_buildInclude('api.draw.js');
-	_buildInclude('api.page.js');
-	_buildInclude('api.ajax.js');
-	_buildInclude('api.selectors.js');
-	_buildInclude('api.rows.js');
-	_buildInclude('api.row.details.js');
-	_buildInclude('api.columns.js');
-	_buildInclude('api.cells.js');
-	_buildInclude('api.order.js');
-	_buildInclude('api.search.js');
-	_buildInclude('api.state.js');
-	_buildInclude('api.static.js');
-	_buildInclude('api.core.js');
+    _buildInclude('api.base.js');
+    _buildInclude('api.table.js');
+    _buildInclude('api.draw.js');
+    _buildInclude('api.exclude.js');
+    _buildInclude('api.page.js');
+    _buildInclude('api.ajax.js');
+    _buildInclude('api.selectors.js');
+    _buildInclude('api.rows.js');
+    _buildInclude('api.row.details.js');
+    _buildInclude('api.columns.js');
+    _buildInclude('api.cells.js');
+    _buildInclude('api.order.js');
+    _buildInclude('api.search.js');
+    _buildInclude('api.state.js');
+    _buildInclude('api.static.js');
+    _buildInclude('api.core.js');
 
-	/**
-	 * Version string for plug-ins to check compatibility. Allowed format is
-	 * `a.b.c-d` where: a:int, b:int, c:int, d:string(dev|beta|alpha). `d` is used
-	 * only for non-release builds. See http://semver.org/ for more information.
-	 *  @member
-	 *  @type string
-	 *  @default Version number
-	 */
-	DataTable.version = "1.10.13";
+    /**
+     * Version string for plug-ins to check compatibility. Allowed format is
+     * `a.b.c-d` where: a:int, b:int, c:int, d:string(dev|beta|alpha). `d` is used
+     * only for non-release builds. See http://semver.org/ for more information.
+     *  @member
+     *  @type string
+     *  @default Version number
+     */
+    DataTable.version = "1.10.13";
 
-	/**
-	 * Private data store, containing all of the settings objects that are
-	 * created for the tables on a given page.
-	 *
-	 * Note that the `DataTable.settings` object is aliased to
-	 * `jQuery.fn.dataTableExt` through which it may be accessed and
-	 * manipulated, or `jQuery.fn.dataTable.settings`.
-	 *  @member
-	 *  @type array
-	 *  @default []
-	 *  @private
-	 */
-	DataTable.settings = [];
+    /**
+     * Private data store, containing all of the settings objects that are
+     * created for the tables on a given page.
+     *
+     * Note that the `DataTable.settings` object is aliased to
+     * `jQuery.fn.dataTableExt` through which it may be accessed and
+     * manipulated, or `jQuery.fn.dataTable.settings`.
+     *  @member
+     *  @type array
+     *  @default []
+     *  @private
+     */
+    DataTable.settings = [];
 
-	/**
-	 * Object models container, for the various models that DataTables has
-	 * available to it. These models define the objects that are used to hold
-	 * the active state and configuration of the table.
-	 *  @namespace
-	 */
-	DataTable.models = {};
-	_buildInclude('model.search.js');
-	_buildInclude('model.row.js');
-	_buildInclude('model.column.js');
-	_buildInclude('model.defaults.js');
-	_buildInclude('model.defaults.columns.js');
-	_buildInclude('model.settings.js');
+    /**
+     * Object models container, for the various models that DataTables has
+     * available to it. These models define the objects that are used to hold
+     * the active state and configuration of the table.
+     *  @namespace
+     */
+    DataTable.models = {};
+    _buildInclude('model.search.js');
+    _buildInclude('model.exclude.js');
+    _buildInclude('model.row.js');
+    _buildInclude('model.column.js');
+    _buildInclude('model.defaults.js');
+    _buildInclude('model.defaults.columns.js');
+    _buildInclude('model.settings.js');
 
-	/**
-	 * Extension object for DataTables that is used to provide all extension
-	 * options.
-	 *
-	 * Note that the `DataTable.ext` object is available through
-	 * `jQuery.fn.dataTable.ext` where it may be accessed and manipulated. It is
-	 * also aliased to `jQuery.fn.dataTableExt` for historic reasons.
-	 *  @namespace
-	 *  @extends DataTable.models.ext
-	 */
-	_buildInclude('ext.js');
-	_buildInclude('ext.classes.js');
-	_buildInclude('ext.paging.js');
-	_buildInclude('ext.types.js');
-	_buildInclude('ext.filter.js');
-	_buildInclude('ext.sorting.js');
-	_buildInclude('ext.renderer.js');
-	_buildInclude('ext.helpers.js');
-	_buildInclude('api.internal.js');
+    /**
+     * Extension object for DataTables that is used to provide all extension
+     * options.
+     *
+     * Note that the `DataTable.ext` object is available through
+     * `jQuery.fn.dataTable.ext` where it may be accessed and manipulated. It is
+     * also aliased to `jQuery.fn.dataTableExt` for historic reasons.
+     *  @namespace
+     *  @extends DataTable.models.ext
+     */
+    _buildInclude('ext.js');
+    _buildInclude('ext.classes.js');
+    _buildInclude('ext.paging.js');
+    _buildInclude('ext.types.js');
+    _buildInclude('ext.filter.js');
+    _buildInclude('ext.sorting.js');
+    _buildInclude('ext.renderer.js');
+    _buildInclude('ext.helpers.js');
+    _buildInclude('api.internal.js');
 
-	// jQuery access
-	$.fn.dataTable = DataTable;
+    // jQuery access
+    $.fn.dataTable = DataTable;
 
-	// Provide access to the host jQuery object (circular reference)
-	DataTable.$ = $;
+    // Provide access to the host jQuery object (circular reference)
+    DataTable.$ = $;
 
-	// Legacy aliases
-	$.fn.dataTableSettings = DataTable.settings;
-	$.fn.dataTableExt = DataTable.ext;
+    // Legacy aliases
+    $.fn.dataTableSettings = DataTable.settings;
+    $.fn.dataTableExt = DataTable.ext;
 
-	// With a capital `D` we return a DataTables API instance rather than a
-	// jQuery object
-	$.fn.DataTable = function ( opts ) {
-		return $(this).dataTable( opts ).api();
-	};
+    // With a capital `D` we return a DataTables API instance rather than a
+    // jQuery object
+    $.fn.DataTable = function ( opts ) {
+        return $(this).dataTable( opts ).api();
+    };
 
-	// All properties that are available to $.fn.dataTable should also be
-	// available on $.fn.DataTable
-	$.each( DataTable, function ( prop, val ) {
-		$.fn.DataTable[ prop ] = val;
-	} );
+    // All properties that are available to $.fn.dataTable should also be
+    // available on $.fn.DataTable
+    $.each( DataTable, function ( prop, val ) {
+        $.fn.DataTable[ prop ] = val;
+    } );
 
 
-	// Information about events fired by DataTables - for documentation.
-	/**
-	 * Draw event, fired whenever the table is redrawn on the page, at the same
-	 * point as fnDrawCallback. This may be useful for binding events or
-	 * performing calculations when the table is altered at all.
-	 *  @name DataTable#draw.dt
-	 *  @event
-	 *  @param {event} e jQuery event object
-	 *  @param {object} o DataTables settings object {@link DataTable.models.oSettings}
-	 */
+    // Information about events fired by DataTables - for documentation.
+    /**
+     * Draw event, fired whenever the table is redrawn on the page, at the same
+     * point as fnDrawCallback. This may be useful for binding events or
+     * performing calculations when the table is altered at all.
+     *  @name DataTable#draw.dt
+     *  @event
+     *  @param {event} e jQuery event object
+     *  @param {object} o DataTables settings object {@link DataTable.models.oSettings}
+     */
 
-	/**
-	 * Search event, fired when the searching applied to the table (using the
-	 * built-in global search, or column filters) is altered.
-	 *  @name DataTable#search.dt
-	 *  @event
-	 *  @param {event} e jQuery event object
-	 *  @param {object} o DataTables settings object {@link DataTable.models.oSettings}
-	 */
+    /**
+     * Search event, fired when the searching applied to the table (using the
+     * built-in global search, or column filters) is altered.
+     *  @name DataTable#search.dt
+     *  @event
+     *  @param {event} e jQuery event object
+     *  @param {object} o DataTables settings object {@link DataTable.models.oSettings}
+     */
 
-	/**
-	 * Page change event, fired when the paging of the table is altered.
-	 *  @name DataTable#page.dt
-	 *  @event
-	 *  @param {event} e jQuery event object
-	 *  @param {object} o DataTables settings object {@link DataTable.models.oSettings}
-	 */
+    /**
+     * Page change event, fired when the paging of the table is altered.
+     *  @name DataTable#page.dt
+     *  @event
+     *  @param {event} e jQuery event object
+     *  @param {object} o DataTables settings object {@link DataTable.models.oSettings}
+     */
 
-	/**
-	 * Order event, fired when the ordering applied to the table is altered.
-	 *  @name DataTable#order.dt
-	 *  @event
-	 *  @param {event} e jQuery event object
-	 *  @param {object} o DataTables settings object {@link DataTable.models.oSettings}
-	 */
+    /**
+     * Order event, fired when the ordering applied to the table is altered.
+     *  @name DataTable#order.dt
+     *  @event
+     *  @param {event} e jQuery event object
+     *  @param {object} o DataTables settings object {@link DataTable.models.oSettings}
+     */
 
-	/**
-	 * DataTables initialisation complete event, fired when the table is fully
-	 * drawn, including Ajax data loaded, if Ajax data is required.
-	 *  @name DataTable#init.dt
-	 *  @event
-	 *  @param {event} e jQuery event object
-	 *  @param {object} oSettings DataTables settings object
-	 *  @param {object} json The JSON object request from the server - only
-	 *    present if client-side Ajax sourced data is used</li></ol>
-	 */
+    /**
+     * DataTables initialisation complete event, fired when the table is fully
+     * drawn, including Ajax data loaded, if Ajax data is required.
+     *  @name DataTable#init.dt
+     *  @event
+     *  @param {event} e jQuery event object
+     *  @param {object} oSettings DataTables settings object
+     *  @param {object} json The JSON object request from the server - only
+     *    present if client-side Ajax sourced data is used</li></ol>
+     */
 
-	/**
-	 * State save event, fired when the table has changed state a new state save
-	 * is required. This event allows modification of the state saving object
-	 * prior to actually doing the save, including addition or other state
-	 * properties (for plug-ins) or modification of a DataTables core property.
-	 *  @name DataTable#stateSaveParams.dt
-	 *  @event
-	 *  @param {event} e jQuery event object
-	 *  @param {object} oSettings DataTables settings object
-	 *  @param {object} json The state information to be saved
-	 */
+    /**
+     * State save event, fired when the table has changed state a new state save
+     * is required. This event allows modification of the state saving object
+     * prior to actually doing the save, including addition or other state
+     * properties (for plug-ins) or modification of a DataTables core property.
+     *  @name DataTable#stateSaveParams.dt
+     *  @event
+     *  @param {event} e jQuery event object
+     *  @param {object} oSettings DataTables settings object
+     *  @param {object} json The state information to be saved
+     */
 
-	/**
-	 * State load event, fired when the table is loading state from the stored
-	 * data, but prior to the settings object being modified by the saved state
-	 * - allowing modification of the saved state is required or loading of
-	 * state for a plug-in.
-	 *  @name DataTable#stateLoadParams.dt
-	 *  @event
-	 *  @param {event} e jQuery event object
-	 *  @param {object} oSettings DataTables settings object
-	 *  @param {object} json The saved state information
-	 */
+    /**
+     * State load event, fired when the table is loading state from the stored
+     * data, but prior to the settings object being modified by the saved state
+     * - allowing modification of the saved state is required or loading of
+     * state for a plug-in.
+     *  @name DataTable#stateLoadParams.dt
+     *  @event
+     *  @param {event} e jQuery event object
+     *  @param {object} oSettings DataTables settings object
+     *  @param {object} json The saved state information
+     */
 
-	/**
-	 * State loaded event, fired when state has been loaded from stored data and
-	 * the settings object has been modified by the loaded data.
-	 *  @name DataTable#stateLoaded.dt
-	 *  @event
-	 *  @param {event} e jQuery event object
-	 *  @param {object} oSettings DataTables settings object
-	 *  @param {object} json The saved state information
-	 */
+    /**
+     * State loaded event, fired when state has been loaded from stored data and
+     * the settings object has been modified by the loaded data.
+     *  @name DataTable#stateLoaded.dt
+     *  @event
+     *  @param {event} e jQuery event object
+     *  @param {object} oSettings DataTables settings object
+     *  @param {object} json The saved state information
+     */
 
-	/**
-	 * Processing event, fired when DataTables is doing some kind of processing
-	 * (be it, order, searcg or anything else). It can be used to indicate to
-	 * the end user that there is something happening, or that something has
-	 * finished.
-	 *  @name DataTable#processing.dt
-	 *  @event
-	 *  @param {event} e jQuery event object
-	 *  @param {object} oSettings DataTables settings object
-	 *  @param {boolean} bShow Flag for if DataTables is doing processing or not
-	 */
+    /**
+     * Processing event, fired when DataTables is doing some kind of processing
+     * (be it, order, searcg or anything else). It can be used to indicate to
+     * the end user that there is something happening, or that something has
+     * finished.
+     *  @name DataTable#processing.dt
+     *  @event
+     *  @param {event} e jQuery event object
+     *  @param {object} oSettings DataTables settings object
+     *  @param {boolean} bShow Flag for if DataTables is doing processing or not
+     */
 
-	/**
-	 * Ajax (XHR) event, fired whenever an Ajax request is completed from a
-	 * request to made to the server for new data. This event is called before
-	 * DataTables processed the returned data, so it can also be used to pre-
-	 * process the data returned from the server, if needed.
-	 *
-	 * Note that this trigger is called in `fnServerData`, if you override
-	 * `fnServerData` and which to use this event, you need to trigger it in you
-	 * success function.
-	 *  @name DataTable#xhr.dt
-	 *  @event
-	 *  @param {event} e jQuery event object
-	 *  @param {object} o DataTables settings object {@link DataTable.models.oSettings}
-	 *  @param {object} json JSON returned from the server
-	 *
-	 *  @example
-	 *     // Use a custom property returned from the server in another DOM element
-	 *     $('#table').dataTable().on('xhr.dt', function (e, settings, json) {
+    /**
+     * Ajax (XHR) event, fired whenever an Ajax request is completed from a
+     * request to made to the server for new data. This event is called before
+     * DataTables processed the returned data, so it can also be used to pre-
+     * process the data returned from the server, if needed.
+     *
+     * Note that this trigger is called in `fnServerData`, if you override
+     * `fnServerData` and which to use this event, you need to trigger it in you
+     * success function.
+     *  @name DataTable#xhr.dt
+     *  @event
+     *  @param {event} e jQuery event object
+     *  @param {object} o DataTables settings object {@link DataTable.models.oSettings}
+     *  @param {object} json JSON returned from the server
+     *
+     *  @example
+     *     // Use a custom property returned from the server in another DOM element
+     *     $('#table').dataTable().on('xhr.dt', function (e, settings, json) {
 	 *       $('#status').html( json.status );
 	 *     } );
-	 *
-	 *  @example
-	 *     // Pre-process the data returned from the server
-	 *     $('#table').dataTable().on('xhr.dt', function (e, settings, json) {
+     *
+     *  @example
+     *     // Pre-process the data returned from the server
+     *     $('#table').dataTable().on('xhr.dt', function (e, settings, json) {
 	 *       for ( var i=0, ien=json.aaData.length ; i<ien ; i++ ) {
 	 *         json.aaData[i].sum = json.aaData[i].one + json.aaData[i].two;
 	 *       }
 	 *       // Note no return - manipulate the data directly in the JSON object.
 	 *     } );
-	 */
+     */
 
-	/**
-	 * Destroy event, fired when the DataTable is destroyed by calling fnDestroy
-	 * or passing the bDestroy:true parameter in the initialisation object. This
-	 * can be used to remove bound events, added DOM nodes, etc.
-	 *  @name DataTable#destroy.dt
-	 *  @event
-	 *  @param {event} e jQuery event object
-	 *  @param {object} o DataTables settings object {@link DataTable.models.oSettings}
-	 */
+    /**
+     * Destroy event, fired when the DataTable is destroyed by calling fnDestroy
+     * or passing the bDestroy:true parameter in the initialisation object. This
+     * can be used to remove bound events, added DOM nodes, etc.
+     *  @name DataTable#destroy.dt
+     *  @event
+     *  @param {event} e jQuery event object
+     *  @param {object} o DataTables settings object {@link DataTable.models.oSettings}
+     */
 
-	/**
-	 * Page length change event, fired when number of records to show on each
-	 * page (the length) is changed.
-	 *  @name DataTable#length.dt
-	 *  @event
-	 *  @param {event} e jQuery event object
-	 *  @param {object} o DataTables settings object {@link DataTable.models.oSettings}
-	 *  @param {integer} len New length
-	 */
+    /**
+     * Page length change event, fired when number of records to show on each
+     * page (the length) is changed.
+     *  @name DataTable#length.dt
+     *  @event
+     *  @param {event} e jQuery event object
+     *  @param {object} o DataTables settings object {@link DataTable.models.oSettings}
+     *  @param {integer} len New length
+     */
 
-	/**
-	 * Column sizing has changed.
-	 *  @name DataTable#column-sizing.dt
-	 *  @event
-	 *  @param {event} e jQuery event object
-	 *  @param {object} o DataTables settings object {@link DataTable.models.oSettings}
-	 */
+    /**
+     * Column sizing has changed.
+     *  @name DataTable#column-sizing.dt
+     *  @event
+     *  @param {event} e jQuery event object
+     *  @param {object} o DataTables settings object {@link DataTable.models.oSettings}
+     */
 
-	/**
-	 * Column visibility has changed.
-	 *  @name DataTable#column-visibility.dt
-	 *  @event
-	 *  @param {event} e jQuery event object
-	 *  @param {object} o DataTables settings object {@link DataTable.models.oSettings}
-	 *  @param {int} column Column index
-	 *  @param {bool} vis `false` if column now hidden, or `true` if visible
-	 */
+    /**
+     * Column visibility has changed.
+     *  @name DataTable#column-visibility.dt
+     *  @event
+     *  @param {event} e jQuery event object
+     *  @param {object} o DataTables settings object {@link DataTable.models.oSettings}
+     *  @param {int} column Column index
+     *  @param {bool} vis `false` if column now hidden, or `true` if visible
+     */
 
-	return $.fn.dataTable;
+    return $.fn.dataTable;
 }));

--- a/js/api/api.exclude.js
+++ b/js/api/api.exclude.js
@@ -1,0 +1,26 @@
+
+
+_api_register( 'exclude()', function ( input, regex, smart, caseInsen ) {
+    var ctx = this.context;
+
+    if ( input === undefined ) {
+        // get
+        return ctx.length !== 0 ?
+            ctx[0].oPreviousExclude.sSearch :
+            undefined;
+    }
+
+    // set
+    return this.iterator( 'table', function ( settings ) {
+        if ( ! settings.oFeatures.bFilter ) {
+            return;
+        }
+
+        _fnExcludeComplete( settings, $.extend( {}, settings.oPreviousExclude, {
+            "sSearch": input+"",
+            "bRegex":  regex === null ? false : regex,
+            "bSmart":  smart === null ? true  : smart,
+            "bCaseInsensitive": caseInsen === null ? true : caseInsen
+        } ), 1 );
+    } );
+} );

--- a/js/api/api.internal.js
+++ b/js/api/api.internal.js
@@ -73,6 +73,7 @@ $.extend( DataTable.ext.internal, {
 	_fnGetUniqueThs: _fnGetUniqueThs,
 	_fnFeatureHtmlFilter: _fnFeatureHtmlFilter,
 	_fnFilterComplete: _fnFilterComplete,
+    _fnExcludeComplete: _fnExcludeComplete,
 	_fnFilterCustom: _fnFilterCustom,
 	_fnFilterColumn: _fnFilterColumn,
 	_fnFilter: _fnFilter,

--- a/js/core/core.ajax.js
+++ b/js/core/core.ajax.js
@@ -9,128 +9,128 @@
  */
 function _fnBuildAjax( oSettings, data, fn )
 {
-	// Compatibility with 1.9-, allow fnServerData and event to manipulate
-	_fnCallbackFire( oSettings, 'aoServerParams', 'serverParams', [data] );
+    // Compatibility with 1.9-, allow fnServerData and event to manipulate
+    _fnCallbackFire( oSettings, 'aoServerParams', 'serverParams', [data] );
 
-	// Convert to object based for 1.10+ if using the old array scheme which can
-	// come from server-side processing or serverParams
-	if ( data && $.isArray(data) ) {
-		var tmp = {};
-		var rbracket = /(.*?)\[\]$/;
+    // Convert to object based for 1.10+ if using the old array scheme which can
+    // come from server-side processing or serverParams
+    if ( data && $.isArray(data) ) {
+        var tmp = {};
+        var rbracket = /(.*?)\[\]$/;
 
-		$.each( data, function (key, val) {
-			var match = val.name.match(rbracket);
+        $.each( data, function (key, val) {
+            var match = val.name.match(rbracket);
 
-			if ( match ) {
-				// Support for arrays
-				var name = match[0];
+            if ( match ) {
+                // Support for arrays
+                var name = match[0];
 
-				if ( ! tmp[ name ] ) {
-					tmp[ name ] = [];
-				}
-				tmp[ name ].push( val.value );
-			}
-			else {
-				tmp[val.name] = val.value;
-			}
-		} );
-		data = tmp;
-	}
+                if ( ! tmp[ name ] ) {
+                    tmp[ name ] = [];
+                }
+                tmp[ name ].push( val.value );
+            }
+            else {
+                tmp[val.name] = val.value;
+            }
+        } );
+        data = tmp;
+    }
 
-	var ajaxData;
-	var ajax = oSettings.ajax;
-	var instance = oSettings.oInstance;
-	var callback = function ( json ) {
-		_fnCallbackFire( oSettings, null, 'xhr', [oSettings, json, oSettings.jqXHR] );
-		fn( json );
-	};
+    var ajaxData;
+    var ajax = oSettings.ajax;
+    var instance = oSettings.oInstance;
+    var callback = function ( json ) {
+        _fnCallbackFire( oSettings, null, 'xhr', [oSettings, json, oSettings.jqXHR] );
+        fn( json );
+    };
 
-	if ( $.isPlainObject( ajax ) && ajax.data )
-	{
-		ajaxData = ajax.data;
+    if ( $.isPlainObject( ajax ) && ajax.data )
+    {
+        ajaxData = ajax.data;
 
-		var newData = $.isFunction( ajaxData ) ?
-			ajaxData( data, oSettings ) :  // fn can manipulate data or return
-			ajaxData;                      // an object object or array to merge
+        var newData = $.isFunction( ajaxData ) ?
+            ajaxData( data, oSettings ) :  // fn can manipulate data or return
+            ajaxData;                      // an object object or array to merge
 
-		// If the function returned something, use that alone
-		data = $.isFunction( ajaxData ) && newData ?
-			newData :
-			$.extend( true, data, newData );
+        // If the function returned something, use that alone
+        data = $.isFunction( ajaxData ) && newData ?
+            newData :
+            $.extend( true, data, newData );
 
-		// Remove the data property as we've resolved it already and don't want
-		// jQuery to do it again (it is restored at the end of the function)
-		delete ajax.data;
-	}
+        // Remove the data property as we've resolved it already and don't want
+        // jQuery to do it again (it is restored at the end of the function)
+        delete ajax.data;
+    }
 
-	var baseAjax = {
-		"data": data,
-		"success": function (json) {
-			var error = json.error || json.sError;
-			if ( error ) {
-				_fnLog( oSettings, 0, error );
-			}
+    var baseAjax = {
+        "data": data,
+        "success": function (json) {
+            var error = json.error || json.sError;
+            if ( error ) {
+                _fnLog( oSettings, 0, error );
+            }
 
-			oSettings.json = json;
-			callback( json );
-		},
-		"dataType": "json",
-		"cache": false,
-		"type": oSettings.sServerMethod,
-		"error": function (xhr, error, thrown) {
-			var ret = _fnCallbackFire( oSettings, null, 'xhr', [oSettings, null, oSettings.jqXHR] );
+            oSettings.json = json;
+            callback( json );
+        },
+        "dataType": "json",
+        "cache": false,
+        "type": oSettings.sServerMethod,
+        "error": function (xhr, error, thrown) {
+            var ret = _fnCallbackFire( oSettings, null, 'xhr', [oSettings, null, oSettings.jqXHR] );
 
-			if ( $.inArray( true, ret ) === -1 ) {
-				if ( error == "parsererror" ) {
-					_fnLog( oSettings, 0, 'Invalid JSON response', 1 );
-				}
-				else if ( xhr.readyState === 4 ) {
-					_fnLog( oSettings, 0, 'Ajax error', 7 );
-				}
-			}
+            if ( $.inArray( true, ret ) === -1 ) {
+                if ( error == "parsererror" ) {
+                    _fnLog( oSettings, 0, 'Invalid JSON response', 1 );
+                }
+                else if ( xhr.readyState === 4 ) {
+                    _fnLog( oSettings, 0, 'Ajax error', 7 );
+                }
+            }
 
-			_fnProcessingDisplay( oSettings, false );
-		}
-	};
+            _fnProcessingDisplay( oSettings, false );
+        }
+    };
 
-	// Store the data submitted for the API
-	oSettings.oAjaxData = data;
+    // Store the data submitted for the API
+    oSettings.oAjaxData = data;
 
-	// Allow plug-ins and external processes to modify the data
-	_fnCallbackFire( oSettings, null, 'preXhr', [oSettings, data] );
+    // Allow plug-ins and external processes to modify the data
+    _fnCallbackFire( oSettings, null, 'preXhr', [oSettings, data] );
 
-	if ( oSettings.fnServerData )
-	{
-		// DataTables 1.9- compatibility
-		oSettings.fnServerData.call( instance,
-			oSettings.sAjaxSource,
-			$.map( data, function (val, key) { // Need to convert back to 1.9 trad format
-				return { name: key, value: val };
-			} ),
-			callback,
-			oSettings
-		);
-	}
-	else if ( oSettings.sAjaxSource || typeof ajax === 'string' )
-	{
-		// DataTables 1.9- compatibility
-		oSettings.jqXHR = $.ajax( $.extend( baseAjax, {
-			url: ajax || oSettings.sAjaxSource
-		} ) );
-	}
-	else if ( $.isFunction( ajax ) )
-	{
-		// Is a function - let the caller define what needs to be done
-		oSettings.jqXHR = ajax.call( instance, data, callback, oSettings );
-	}
-	else
-	{
-		// Object to extend the base settings
-		oSettings.jqXHR = $.ajax( $.extend( baseAjax, ajax ) );
+    if ( oSettings.fnServerData )
+    {
+        // DataTables 1.9- compatibility
+        oSettings.fnServerData.call( instance,
+            oSettings.sAjaxSource,
+            $.map( data, function (val, key) { // Need to convert back to 1.9 trad format
+                return { name: key, value: val };
+            } ),
+            callback,
+            oSettings
+        );
+    }
+    else if ( oSettings.sAjaxSource || typeof ajax === 'string' )
+    {
+        // DataTables 1.9- compatibility
+        oSettings.jqXHR = $.ajax( $.extend( baseAjax, {
+            url: ajax || oSettings.sAjaxSource
+        } ) );
+    }
+    else if ( $.isFunction( ajax ) )
+    {
+        // Is a function - let the caller define what needs to be done
+        oSettings.jqXHR = ajax.call( instance, data, callback, oSettings );
+    }
+    else
+    {
+        // Object to extend the base settings
+        oSettings.jqXHR = $.ajax( $.extend( baseAjax, ajax ) );
 
-		// Restore for next time around
-		ajax.data = ajaxData;
-	}
+        // Restore for next time around
+        ajax.data = ajaxData;
+    }
 }
 
 
@@ -142,21 +142,21 @@ function _fnBuildAjax( oSettings, data, fn )
  */
 function _fnAjaxUpdate( settings )
 {
-	if ( settings.bAjaxDataGet ) {
-		settings.iDraw++;
-		_fnProcessingDisplay( settings, true );
+    if ( settings.bAjaxDataGet ) {
+        settings.iDraw++;
+        _fnProcessingDisplay( settings, true );
 
-		_fnBuildAjax(
-			settings,
-			_fnAjaxParameters( settings ),
-			function(json) {
-				_fnAjaxUpdateDraw( settings, json );
-			}
-		);
+        _fnBuildAjax(
+            settings,
+            _fnAjaxParameters( settings ),
+            function(json) {
+                _fnAjaxUpdateDraw( settings, json );
+            }
+        );
 
-		return false;
-	}
-	return true;
+        return false;
+    }
+    return true;
 }
 
 
@@ -173,98 +173,106 @@ function _fnAjaxUpdate( settings )
  */
 function _fnAjaxParameters( settings )
 {
-	var
-		columns = settings.aoColumns,
-		columnCount = columns.length,
-		features = settings.oFeatures,
-		preSearch = settings.oPreviousSearch,
-		preColSearch = settings.aoPreSearchCols,
-		i, data = [], dataProp, column, columnSearch,
-		sort = _fnSortFlatten( settings ),
-		displayStart = settings._iDisplayStart,
-		displayLength = features.bPaginate !== false ?
-			settings._iDisplayLength :
-			-1;
+    var
+        columns = settings.aoColumns,
+        columnCount = columns.length,
+        features = settings.oFeatures,
+        preSearch = settings.oPreviousSearch,
+        preExclude = settings.oPreviousExclude,
+        preColSearch = settings.aoPreSearchCols,
+        i, data = [], dataProp, column, columnSearch,
+        sort = _fnSortFlatten( settings ),
+        displayStart = settings._iDisplayStart,
+        displayLength = features.bPaginate !== false ?
+            settings._iDisplayLength :
+            -1;
 
-	var param = function ( name, value ) {
-		data.push( { 'name': name, 'value': value } );
-	};
+    var param = function ( name, value ) {
+        data.push( { 'name': name, 'value': value } );
+    };
 
-	// DataTables 1.9- compatible method
-	param( 'sEcho',          settings.iDraw );
-	param( 'iColumns',       columnCount );
-	param( 'sColumns',       _pluck( columns, 'sName' ).join(',') );
-	param( 'iDisplayStart',  displayStart );
-	param( 'iDisplayLength', displayLength );
+    // DataTables 1.9- compatible method
+    param( 'sEcho',          settings.iDraw );
+    param( 'iColumns',       columnCount );
+    param( 'sColumns',       _pluck( columns, 'sName' ).join(',') );
+    param( 'iDisplayStart',  displayStart );
+    param( 'iDisplayLength', displayLength );
 
-	// DataTables 1.10+ method
-	var d = {
-		draw:    settings.iDraw,
-		columns: [],
-		order:   [],
-		start:   displayStart,
-		length:  displayLength,
-		search:  {
-			value: preSearch.sSearch,
-			regex: preSearch.bRegex
-		}
-	};
+    // DataTables 1.10+ method
+    var d = {
+        draw:    settings.iDraw,
+        columns: [],
+        order:   [],
+        start:   displayStart,
+        length:  displayLength,
+        exclude: {
+            value: preExclude.sSearch,
+            regex: preExclude.bRegex
+        },
+        search:  {
+            value: preSearch.sSearch,
+            regex: preSearch.bRegex
+        }
+    };
 
-	for ( i=0 ; i<columnCount ; i++ ) {
-		column = columns[i];
-		columnSearch = preColSearch[i];
-		dataProp = typeof column.mData=="function" ? 'function' : column.mData ;
+    for ( i=0 ; i<columnCount ; i++ ) {
+        column = columns[i];
+        columnSearch = preColSearch[i];
+        dataProp = typeof column.mData=="function" ? 'function' : column.mData ;
 
-		d.columns.push( {
-			data:       dataProp,
-			name:       column.sName,
-			searchable: column.bSearchable,
-			orderable:  column.bSortable,
-			search:     {
-				value: columnSearch.sSearch,
-				regex: columnSearch.bRegex
-			}
-		} );
+        d.columns.push( {
+            data:       dataProp,
+            name:       column.sName,
+            searchable: column.bSearchable,
+            orderable:  column.bSortable,
+            search:     {
+                value: columnSearch.sSearch,
+                regex: columnSearch.bRegex
+            }
+        } );
 
-		param( "mDataProp_"+i, dataProp );
+        param( "mDataProp_"+i, dataProp );
 
-		if ( features.bFilter ) {
-			param( 'sSearch_'+i,     columnSearch.sSearch );
-			param( 'bRegex_'+i,      columnSearch.bRegex );
-			param( 'bSearchable_'+i, column.bSearchable );
-		}
+        if ( features.bFilter ) {
+            param( 'sSearch_'+i,     columnSearch.sSearch );
+            param( 'bRegex_'+i,      columnSearch.bRegex );
+            param( 'bSearchable_'+i, column.bSearchable );
+        }
 
-		if ( features.bSort ) {
-			param( 'bSortable_'+i, column.bSortable );
-		}
-	}
+        if ( features.bSort ) {
+            param( 'bSortable_'+i, column.bSortable );
+        }
+    }
 
-	if ( features.bFilter ) {
-		param( 'sSearch', preSearch.sSearch );
-		param( 'bRegex', preSearch.bRegex );
-	}
+    if ( features.bFilter ) {
+        param( 'sSearch', preSearch.sSearch );
+        param( 'bRegex', preSearch.bRegex );
+    }
 
-	if ( features.bSort ) {
-		$.each( sort, function ( i, val ) {
-			d.order.push( { column: val.col, dir: val.dir } );
+    if ( features.bFilter ) {
+        param( 'sExclude', preExclude.sSearch );
+    }
+    if ( features.bSort ) {
+        $.each( sort, function ( i, val ) {
+            d.order.push( { column: val.col, dir: val.dir } );
 
-			param( 'iSortCol_'+i, val.col );
-			param( 'sSortDir_'+i, val.dir );
-		} );
+            param( 'iSortCol_'+i, val.col );
+            param( 'sSortDir_'+i, val.dir );
+        } );
 
-		param( 'iSortingCols', sort.length );
-	}
+        param( 'iSortingCols', sort.length );
+    }
 
-	// If the legacy.ajax parameter is null, then we automatically decide which
-	// form to use, based on sAjaxSource
-	var legacy = DataTable.ext.legacy.ajax;
-	if ( legacy === null ) {
-		return settings.sAjaxSource ? data : d;
-	}
+    // If the legacy.ajax parameter is null, then we automatically decide which
+    // form to use, based on sAjaxSource
+    var legacy = DataTable.ext.legacy.ajax;
+    if ( legacy === null ) {
+        return settings.sAjaxSource ? data : d;
+    }
 
-	// Otherwise, if legacy has been specified then we use that to decide on the
-	// form
-	return legacy ? data : d;
+    // Otherwise, if legacy has been specified then we use that to decide on the
+    // form
+    return legacy ? data : d;
 }
 
 
@@ -281,43 +289,43 @@ function _fnAjaxParameters( settings )
  */
 function _fnAjaxUpdateDraw ( settings, json )
 {
-	// v1.10 uses camelCase variables, while 1.9 uses Hungarian notation.
-	// Support both
-	var compat = function ( old, modern ) {
-		return json[old] !== undefined ? json[old] : json[modern];
-	};
+    // v1.10 uses camelCase variables, while 1.9 uses Hungarian notation.
+    // Support both
+    var compat = function ( old, modern ) {
+        return json[old] !== undefined ? json[old] : json[modern];
+    };
 
-	var data = _fnAjaxDataSrc( settings, json );
-	var draw            = compat( 'sEcho',                'draw' );
-	var recordsTotal    = compat( 'iTotalRecords',        'recordsTotal' );
-	var recordsFiltered = compat( 'iTotalDisplayRecords', 'recordsFiltered' );
+    var data = _fnAjaxDataSrc( settings, json );
+    var draw            = compat( 'sEcho',                'draw' );
+    var recordsTotal    = compat( 'iTotalRecords',        'recordsTotal' );
+    var recordsFiltered = compat( 'iTotalDisplayRecords', 'recordsFiltered' );
 
-	if ( draw ) {
-		// Protect against out of sequence returns
-		if ( draw*1 < settings.iDraw ) {
-			return;
-		}
-		settings.iDraw = draw * 1;
-	}
+    if ( draw ) {
+        // Protect against out of sequence returns
+        if ( draw*1 < settings.iDraw ) {
+            return;
+        }
+        settings.iDraw = draw * 1;
+    }
 
-	_fnClearTable( settings );
-	settings._iRecordsTotal   = parseInt(recordsTotal, 10);
-	settings._iRecordsDisplay = parseInt(recordsFiltered, 10);
+    _fnClearTable( settings );
+    settings._iRecordsTotal   = parseInt(recordsTotal, 10);
+    settings._iRecordsDisplay = parseInt(recordsFiltered, 10);
 
-	for ( var i=0, ien=data.length ; i<ien ; i++ ) {
-		_fnAddData( settings, data[i] );
-	}
-	settings.aiDisplay = settings.aiDisplayMaster.slice();
+    for ( var i=0, ien=data.length ; i<ien ; i++ ) {
+        _fnAddData( settings, data[i] );
+    }
+    settings.aiDisplay = settings.aiDisplayMaster.slice();
 
-	settings.bAjaxDataGet = false;
-	_fnDraw( settings );
+    settings.bAjaxDataGet = false;
+    _fnDraw( settings );
 
-	if ( ! settings._bInitComplete ) {
-		_fnInitComplete( settings, json );
-	}
+    if ( ! settings._bInitComplete ) {
+        _fnInitComplete( settings, json );
+    }
 
-	settings.bAjaxDataGet = true;
-	_fnProcessingDisplay( settings, false );
+    settings.bAjaxDataGet = true;
+    _fnProcessingDisplay( settings, false );
 }
 
 
@@ -331,17 +339,17 @@ function _fnAjaxUpdateDraw ( settings, json )
  */
 function _fnAjaxDataSrc ( oSettings, json )
 {
-	var dataSrc = $.isPlainObject( oSettings.ajax ) && oSettings.ajax.dataSrc !== undefined ?
-		oSettings.ajax.dataSrc :
-		oSettings.sAjaxDataProp; // Compatibility with 1.9-.
+    var dataSrc = $.isPlainObject( oSettings.ajax ) && oSettings.ajax.dataSrc !== undefined ?
+        oSettings.ajax.dataSrc :
+        oSettings.sAjaxDataProp; // Compatibility with 1.9-.
 
-	// Compatibility with 1.9-. In order to read from aaData, check if the
-	// default has been changed, if not, check for aaData
-	if ( dataSrc === 'data' ) {
-		return json.aaData || json[dataSrc];
-	}
+    // Compatibility with 1.9-. In order to read from aaData, check if the
+    // default has been changed, if not, check for aaData
+    if ( dataSrc === 'data' ) {
+        return json.aaData || json[dataSrc];
+    }
 
-	return dataSrc !== "" ?
-		_fnGetObjectDataFn( dataSrc )( json ) :
-		json;
+    return dataSrc !== "" ?
+        _fnGetObjectDataFn( dataSrc )( json ) :
+        json;
 }

--- a/js/core/core.ajax.js
+++ b/js/core/core.ajax.js
@@ -9,128 +9,128 @@
  */
 function _fnBuildAjax( oSettings, data, fn )
 {
-    // Compatibility with 1.9-, allow fnServerData and event to manipulate
-    _fnCallbackFire( oSettings, 'aoServerParams', 'serverParams', [data] );
+	// Compatibility with 1.9-, allow fnServerData and event to manipulate
+	_fnCallbackFire( oSettings, 'aoServerParams', 'serverParams', [data] );
 
-    // Convert to object based for 1.10+ if using the old array scheme which can
-    // come from server-side processing or serverParams
-    if ( data && $.isArray(data) ) {
-        var tmp = {};
-        var rbracket = /(.*?)\[\]$/;
+	// Convert to object based for 1.10+ if using the old array scheme which can
+	// come from server-side processing or serverParams
+	if ( data && $.isArray(data) ) {
+		var tmp = {};
+		var rbracket = /(.*?)\[\]$/;
 
-        $.each( data, function (key, val) {
-            var match = val.name.match(rbracket);
+		$.each( data, function (key, val) {
+			var match = val.name.match(rbracket);
 
-            if ( match ) {
-                // Support for arrays
-                var name = match[0];
+			if ( match ) {
+				// Support for arrays
+				var name = match[0];
 
-                if ( ! tmp[ name ] ) {
-                    tmp[ name ] = [];
-                }
-                tmp[ name ].push( val.value );
-            }
-            else {
-                tmp[val.name] = val.value;
-            }
-        } );
-        data = tmp;
-    }
+				if ( ! tmp[ name ] ) {
+					tmp[ name ] = [];
+				}
+				tmp[ name ].push( val.value );
+			}
+			else {
+				tmp[val.name] = val.value;
+			}
+		} );
+		data = tmp;
+	}
 
-    var ajaxData;
-    var ajax = oSettings.ajax;
-    var instance = oSettings.oInstance;
-    var callback = function ( json ) {
-        _fnCallbackFire( oSettings, null, 'xhr', [oSettings, json, oSettings.jqXHR] );
-        fn( json );
-    };
+	var ajaxData;
+	var ajax = oSettings.ajax;
+	var instance = oSettings.oInstance;
+	var callback = function ( json ) {
+		_fnCallbackFire( oSettings, null, 'xhr', [oSettings, json, oSettings.jqXHR] );
+		fn( json );
+	};
 
-    if ( $.isPlainObject( ajax ) && ajax.data )
-    {
-        ajaxData = ajax.data;
+	if ( $.isPlainObject( ajax ) && ajax.data )
+	{
+		ajaxData = ajax.data;
 
-        var newData = $.isFunction( ajaxData ) ?
-            ajaxData( data, oSettings ) :  // fn can manipulate data or return
-            ajaxData;                      // an object object or array to merge
+		var newData = $.isFunction( ajaxData ) ?
+			ajaxData( data, oSettings ) :  // fn can manipulate data or return
+			ajaxData;                      // an object object or array to merge
 
-        // If the function returned something, use that alone
-        data = $.isFunction( ajaxData ) && newData ?
-            newData :
-            $.extend( true, data, newData );
+		// If the function returned something, use that alone
+		data = $.isFunction( ajaxData ) && newData ?
+			newData :
+			$.extend( true, data, newData );
 
-        // Remove the data property as we've resolved it already and don't want
-        // jQuery to do it again (it is restored at the end of the function)
-        delete ajax.data;
-    }
+		// Remove the data property as we've resolved it already and don't want
+		// jQuery to do it again (it is restored at the end of the function)
+		delete ajax.data;
+	}
 
-    var baseAjax = {
-        "data": data,
-        "success": function (json) {
-            var error = json.error || json.sError;
-            if ( error ) {
-                _fnLog( oSettings, 0, error );
-            }
+	var baseAjax = {
+		"data": data,
+		"success": function (json) {
+			var error = json.error || json.sError;
+			if ( error ) {
+				_fnLog( oSettings, 0, error );
+			}
 
-            oSettings.json = json;
-            callback( json );
-        },
-        "dataType": "json",
-        "cache": false,
-        "type": oSettings.sServerMethod,
-        "error": function (xhr, error, thrown) {
-            var ret = _fnCallbackFire( oSettings, null, 'xhr', [oSettings, null, oSettings.jqXHR] );
+			oSettings.json = json;
+			callback( json );
+		},
+		"dataType": "json",
+		"cache": false,
+		"type": oSettings.sServerMethod,
+		"error": function (xhr, error, thrown) {
+			var ret = _fnCallbackFire( oSettings, null, 'xhr', [oSettings, null, oSettings.jqXHR] );
 
-            if ( $.inArray( true, ret ) === -1 ) {
-                if ( error == "parsererror" ) {
-                    _fnLog( oSettings, 0, 'Invalid JSON response', 1 );
-                }
-                else if ( xhr.readyState === 4 ) {
-                    _fnLog( oSettings, 0, 'Ajax error', 7 );
-                }
-            }
+			if ( $.inArray( true, ret ) === -1 ) {
+				if ( error == "parsererror" ) {
+					_fnLog( oSettings, 0, 'Invalid JSON response', 1 );
+				}
+				else if ( xhr.readyState === 4 ) {
+					_fnLog( oSettings, 0, 'Ajax error', 7 );
+				}
+			}
 
-            _fnProcessingDisplay( oSettings, false );
-        }
-    };
+			_fnProcessingDisplay( oSettings, false );
+		}
+	};
 
-    // Store the data submitted for the API
-    oSettings.oAjaxData = data;
+	// Store the data submitted for the API
+	oSettings.oAjaxData = data;
 
-    // Allow plug-ins and external processes to modify the data
-    _fnCallbackFire( oSettings, null, 'preXhr', [oSettings, data] );
+	// Allow plug-ins and external processes to modify the data
+	_fnCallbackFire( oSettings, null, 'preXhr', [oSettings, data] );
 
-    if ( oSettings.fnServerData )
-    {
-        // DataTables 1.9- compatibility
-        oSettings.fnServerData.call( instance,
-            oSettings.sAjaxSource,
-            $.map( data, function (val, key) { // Need to convert back to 1.9 trad format
-                return { name: key, value: val };
-            } ),
-            callback,
-            oSettings
-        );
-    }
-    else if ( oSettings.sAjaxSource || typeof ajax === 'string' )
-    {
-        // DataTables 1.9- compatibility
-        oSettings.jqXHR = $.ajax( $.extend( baseAjax, {
-            url: ajax || oSettings.sAjaxSource
-        } ) );
-    }
-    else if ( $.isFunction( ajax ) )
-    {
-        // Is a function - let the caller define what needs to be done
-        oSettings.jqXHR = ajax.call( instance, data, callback, oSettings );
-    }
-    else
-    {
-        // Object to extend the base settings
-        oSettings.jqXHR = $.ajax( $.extend( baseAjax, ajax ) );
+	if ( oSettings.fnServerData )
+	{
+		// DataTables 1.9- compatibility
+		oSettings.fnServerData.call( instance,
+			oSettings.sAjaxSource,
+			$.map( data, function (val, key) { // Need to convert back to 1.9 trad format
+				return { name: key, value: val };
+			} ),
+			callback,
+			oSettings
+		);
+	}
+	else if ( oSettings.sAjaxSource || typeof ajax === 'string' )
+	{
+		// DataTables 1.9- compatibility
+		oSettings.jqXHR = $.ajax( $.extend( baseAjax, {
+			url: ajax || oSettings.sAjaxSource
+		} ) );
+	}
+	else if ( $.isFunction( ajax ) )
+	{
+		// Is a function - let the caller define what needs to be done
+		oSettings.jqXHR = ajax.call( instance, data, callback, oSettings );
+	}
+	else
+	{
+		// Object to extend the base settings
+		oSettings.jqXHR = $.ajax( $.extend( baseAjax, ajax ) );
 
-        // Restore for next time around
-        ajax.data = ajaxData;
-    }
+		// Restore for next time around
+		ajax.data = ajaxData;
+	}
 }
 
 
@@ -142,21 +142,21 @@ function _fnBuildAjax( oSettings, data, fn )
  */
 function _fnAjaxUpdate( settings )
 {
-    if ( settings.bAjaxDataGet ) {
-        settings.iDraw++;
-        _fnProcessingDisplay( settings, true );
+	if ( settings.bAjaxDataGet ) {
+		settings.iDraw++;
+		_fnProcessingDisplay( settings, true );
 
-        _fnBuildAjax(
-            settings,
-            _fnAjaxParameters( settings ),
-            function(json) {
-                _fnAjaxUpdateDraw( settings, json );
-            }
-        );
+		_fnBuildAjax(
+			settings,
+			_fnAjaxParameters( settings ),
+			function(json) {
+				_fnAjaxUpdateDraw( settings, json );
+			}
+		);
 
-        return false;
-    }
-    return true;
+		return false;
+	}
+	return true;
 }
 
 
@@ -173,106 +173,105 @@ function _fnAjaxUpdate( settings )
  */
 function _fnAjaxParameters( settings )
 {
-    var
-        columns = settings.aoColumns,
-        columnCount = columns.length,
-        features = settings.oFeatures,
-        preSearch = settings.oPreviousSearch,
+	var
+		columns = settings.aoColumns,
+		columnCount = columns.length,
+		features = settings.oFeatures,
+		preSearch = settings.oPreviousSearch,
         preExclude = settings.oPreviousExclude,
-        preColSearch = settings.aoPreSearchCols,
-        i, data = [], dataProp, column, columnSearch,
-        sort = _fnSortFlatten( settings ),
-        displayStart = settings._iDisplayStart,
-        displayLength = features.bPaginate !== false ?
-            settings._iDisplayLength :
-            -1;
+		preColSearch = settings.aoPreSearchCols,
+		i, data = [], dataProp, column, columnSearch,
+		sort = _fnSortFlatten( settings ),
+		displayStart = settings._iDisplayStart,
+		displayLength = features.bPaginate !== false ?
+			settings._iDisplayLength :
+			-1;
 
-    var param = function ( name, value ) {
-        data.push( { 'name': name, 'value': value } );
-    };
+	var param = function ( name, value ) {
+		data.push( { 'name': name, 'value': value } );
+	};
 
-    // DataTables 1.9- compatible method
-    param( 'sEcho',          settings.iDraw );
-    param( 'iColumns',       columnCount );
-    param( 'sColumns',       _pluck( columns, 'sName' ).join(',') );
-    param( 'iDisplayStart',  displayStart );
-    param( 'iDisplayLength', displayLength );
+	// DataTables 1.9- compatible method
+	param( 'sEcho',          settings.iDraw );
+	param( 'iColumns',       columnCount );
+	param( 'sColumns',       _pluck( columns, 'sName' ).join(',') );
+	param( 'iDisplayStart',  displayStart );
+	param( 'iDisplayLength', displayLength );
 
-    // DataTables 1.10+ method
-    var d = {
-        draw:    settings.iDraw,
-        columns: [],
-        order:   [],
-        start:   displayStart,
-        length:  displayLength,
+	// DataTables 1.10+ method
+	var d = {
+		draw:    settings.iDraw,
+		columns: [],
+		order:   [],
+		start:   displayStart,
+		length:  displayLength,
         exclude: {
             value: preExclude.sSearch,
             regex: preExclude.bRegex
         },
         search:  {
-            value: preSearch.sSearch,
-            regex: preSearch.bRegex
-        }
-    };
+			value: preSearch.sSearch,
+			regex: preSearch.bRegex
+		}
+	};
 
-    for ( i=0 ; i<columnCount ; i++ ) {
-        column = columns[i];
-        columnSearch = preColSearch[i];
-        dataProp = typeof column.mData=="function" ? 'function' : column.mData ;
+	for ( i=0 ; i<columnCount ; i++ ) {
+		column = columns[i];
+		columnSearch = preColSearch[i];
+		dataProp = typeof column.mData=="function" ? 'function' : column.mData ;
 
-        d.columns.push( {
-            data:       dataProp,
-            name:       column.sName,
-            searchable: column.bSearchable,
-            orderable:  column.bSortable,
-            search:     {
-                value: columnSearch.sSearch,
-                regex: columnSearch.bRegex
-            }
-        } );
+		d.columns.push( {
+			data:       dataProp,
+			name:       column.sName,
+			searchable: column.bSearchable,
+			orderable:  column.bSortable,
+			search:     {
+				value: columnSearch.sSearch,
+				regex: columnSearch.bRegex
+			}
+		} );
 
-        param( "mDataProp_"+i, dataProp );
+		param( "mDataProp_"+i, dataProp );
 
-        if ( features.bFilter ) {
-            param( 'sSearch_'+i,     columnSearch.sSearch );
-            param( 'bRegex_'+i,      columnSearch.bRegex );
-            param( 'bSearchable_'+i, column.bSearchable );
-        }
+		if ( features.bFilter ) {
+			param( 'sSearch_'+i,     columnSearch.sSearch );
+			param( 'bRegex_'+i,      columnSearch.bRegex );
+			param( 'bSearchable_'+i, column.bSearchable );
+		}
 
-        if ( features.bSort ) {
-            param( 'bSortable_'+i, column.bSortable );
-        }
-    }
+		if ( features.bSort ) {
+			param( 'bSortable_'+i, column.bSortable );
+		}
+	}
 
-    if ( features.bFilter ) {
-        param( 'sSearch', preSearch.sSearch );
-        param( 'bRegex', preSearch.bRegex );
-    }
-
+	if ( features.bFilter ) {
+		param( 'sSearch', preSearch.sSearch );
+		param( 'bRegex', preSearch.bRegex );
+	}
     if ( features.bFilter ) {
         param( 'sExclude', preExclude.sSearch );
     }
-    if ( features.bSort ) {
-        $.each( sort, function ( i, val ) {
-            d.order.push( { column: val.col, dir: val.dir } );
+	if ( features.bSort ) {
+		$.each( sort, function ( i, val ) {
+			d.order.push( { column: val.col, dir: val.dir } );
 
-            param( 'iSortCol_'+i, val.col );
-            param( 'sSortDir_'+i, val.dir );
-        } );
+			param( 'iSortCol_'+i, val.col );
+			param( 'sSortDir_'+i, val.dir );
+		} );
 
-        param( 'iSortingCols', sort.length );
-    }
+		param( 'iSortingCols', sort.length );
+	}
 
-    // If the legacy.ajax parameter is null, then we automatically decide which
-    // form to use, based on sAjaxSource
-    var legacy = DataTable.ext.legacy.ajax;
-    if ( legacy === null ) {
-        return settings.sAjaxSource ? data : d;
-    }
+	// If the legacy.ajax parameter is null, then we automatically decide which
+	// form to use, based on sAjaxSource
+	var legacy = DataTable.ext.legacy.ajax;
+	if ( legacy === null ) {
+		return settings.sAjaxSource ? data : d;
+	}
 
-    // Otherwise, if legacy has been specified then we use that to decide on the
-    // form
-    return legacy ? data : d;
+	// Otherwise, if legacy has been specified then we use that to decide on the
+	// form
+	return legacy ? data : d;
 }
 
 
@@ -289,43 +288,43 @@ function _fnAjaxParameters( settings )
  */
 function _fnAjaxUpdateDraw ( settings, json )
 {
-    // v1.10 uses camelCase variables, while 1.9 uses Hungarian notation.
-    // Support both
-    var compat = function ( old, modern ) {
-        return json[old] !== undefined ? json[old] : json[modern];
-    };
+	// v1.10 uses camelCase variables, while 1.9 uses Hungarian notation.
+	// Support both
+	var compat = function ( old, modern ) {
+		return json[old] !== undefined ? json[old] : json[modern];
+	};
 
-    var data = _fnAjaxDataSrc( settings, json );
-    var draw            = compat( 'sEcho',                'draw' );
-    var recordsTotal    = compat( 'iTotalRecords',        'recordsTotal' );
-    var recordsFiltered = compat( 'iTotalDisplayRecords', 'recordsFiltered' );
+	var data = _fnAjaxDataSrc( settings, json );
+	var draw            = compat( 'sEcho',                'draw' );
+	var recordsTotal    = compat( 'iTotalRecords',        'recordsTotal' );
+	var recordsFiltered = compat( 'iTotalDisplayRecords', 'recordsFiltered' );
 
-    if ( draw ) {
-        // Protect against out of sequence returns
-        if ( draw*1 < settings.iDraw ) {
-            return;
-        }
-        settings.iDraw = draw * 1;
-    }
+	if ( draw ) {
+		// Protect against out of sequence returns
+		if ( draw*1 < settings.iDraw ) {
+			return;
+		}
+		settings.iDraw = draw * 1;
+	}
 
-    _fnClearTable( settings );
-    settings._iRecordsTotal   = parseInt(recordsTotal, 10);
-    settings._iRecordsDisplay = parseInt(recordsFiltered, 10);
+	_fnClearTable( settings );
+	settings._iRecordsTotal   = parseInt(recordsTotal, 10);
+	settings._iRecordsDisplay = parseInt(recordsFiltered, 10);
 
-    for ( var i=0, ien=data.length ; i<ien ; i++ ) {
-        _fnAddData( settings, data[i] );
-    }
-    settings.aiDisplay = settings.aiDisplayMaster.slice();
+	for ( var i=0, ien=data.length ; i<ien ; i++ ) {
+		_fnAddData( settings, data[i] );
+	}
+	settings.aiDisplay = settings.aiDisplayMaster.slice();
 
-    settings.bAjaxDataGet = false;
-    _fnDraw( settings );
+	settings.bAjaxDataGet = false;
+	_fnDraw( settings );
 
-    if ( ! settings._bInitComplete ) {
-        _fnInitComplete( settings, json );
-    }
+	if ( ! settings._bInitComplete ) {
+		_fnInitComplete( settings, json );
+	}
 
-    settings.bAjaxDataGet = true;
-    _fnProcessingDisplay( settings, false );
+	settings.bAjaxDataGet = true;
+	_fnProcessingDisplay( settings, false );
 }
 
 
@@ -339,17 +338,17 @@ function _fnAjaxUpdateDraw ( settings, json )
  */
 function _fnAjaxDataSrc ( oSettings, json )
 {
-    var dataSrc = $.isPlainObject( oSettings.ajax ) && oSettings.ajax.dataSrc !== undefined ?
-        oSettings.ajax.dataSrc :
-        oSettings.sAjaxDataProp; // Compatibility with 1.9-.
+	var dataSrc = $.isPlainObject( oSettings.ajax ) && oSettings.ajax.dataSrc !== undefined ?
+		oSettings.ajax.dataSrc :
+		oSettings.sAjaxDataProp; // Compatibility with 1.9-.
 
-    // Compatibility with 1.9-. In order to read from aaData, check if the
-    // default has been changed, if not, check for aaData
-    if ( dataSrc === 'data' ) {
-        return json.aaData || json[dataSrc];
-    }
+	// Compatibility with 1.9-. In order to read from aaData, check if the
+	// default has been changed, if not, check for aaData
+	if ( dataSrc === 'data' ) {
+		return json.aaData || json[dataSrc];
+	}
 
-    return dataSrc !== "" ?
-        _fnGetObjectDataFn( dataSrc )( json ) :
-        json;
+	return dataSrc !== "" ?
+		_fnGetObjectDataFn( dataSrc )( json ) :
+		json;
 }

--- a/js/core/core.constructor.js
+++ b/js/core/core.constructor.js
@@ -9,8 +9,8 @@ var $this = $(this);
 /* Sanity check */
 if ( this.nodeName.toLowerCase() != 'table' )
 {
-    _fnLog( null, 0, 'Non-table node initialisation ('+this.nodeName+')', 2 );
-    return;
+	_fnLog( null, 0, 'Non-table node initialisation ('+this.nodeName+')', 2 );
+	return;
 }
 
 /* Backwards compatibility for the defaults */
@@ -30,54 +30,54 @@ _fnCamelToHungarian( defaults, $.extend( oInit, $this.data() ) );
 var allSettings = DataTable.settings;
 for ( i=0, iLen=allSettings.length ; i<iLen ; i++ )
 {
-    var s = allSettings[i];
+	var s = allSettings[i];
 
 	/* Base check on table node */
-    if ( s.nTable == this || s.nTHead.parentNode == this || (s.nTFoot && s.nTFoot.parentNode == this) )
-    {
-        var bRetrieve = oInit.bRetrieve !== undefined ? oInit.bRetrieve : defaults.bRetrieve;
-        var bDestroy = oInit.bDestroy !== undefined ? oInit.bDestroy : defaults.bDestroy;
+	if ( s.nTable == this || s.nTHead.parentNode == this || (s.nTFoot && s.nTFoot.parentNode == this) )
+	{
+		var bRetrieve = oInit.bRetrieve !== undefined ? oInit.bRetrieve : defaults.bRetrieve;
+		var bDestroy = oInit.bDestroy !== undefined ? oInit.bDestroy : defaults.bDestroy;
 
-        if ( emptyInit || bRetrieve )
-        {
-            return s.oInstance;
-        }
-        else if ( bDestroy )
-        {
-            s.oInstance.fnDestroy();
-            break;
-        }
-        else
-        {
-            _fnLog( s, 0, 'Cannot reinitialise DataTable', 3 );
-            return;
-        }
-    }
+		if ( emptyInit || bRetrieve )
+		{
+			return s.oInstance;
+		}
+		else if ( bDestroy )
+		{
+			s.oInstance.fnDestroy();
+			break;
+		}
+		else
+		{
+			_fnLog( s, 0, 'Cannot reinitialise DataTable', 3 );
+			return;
+		}
+	}
 
 	/* If the element we are initialising has the same ID as a table which was previously
 	 * initialised, but the table nodes don't match (from before) then we destroy the old
 	 * instance by simply deleting it. This is under the assumption that the table has been
 	 * destroyed by other methods. Anyone using non-id selectors will need to do this manually
 	 */
-    if ( s.sTableId == this.id )
-    {
-        allSettings.splice( i, 1 );
-        break;
-    }
+	if ( s.sTableId == this.id )
+	{
+		allSettings.splice( i, 1 );
+		break;
+	}
 }
 
 /* Ensure the table has an ID - required for accessibility */
 if ( sId === null || sId === "" )
 {
-    sId = "DataTables_Table_"+(DataTable.ext._unique++);
-    this.id = sId;
+	sId = "DataTables_Table_"+(DataTable.ext._unique++);
+	this.id = sId;
 }
 
 /* Create the settings object for this table and set some of the default parameters */
 var oSettings = $.extend( true, {}, DataTable.models.oSettings, {
-    "sDestroyWidth": $this[0].style.width,
-    "sInstance":     sId,
-    "sTableId":      sId
+	"sDestroyWidth": $this[0].style.width,
+	"sInstance":     sId,
+	"sTableId":      sId
 } );
 oSettings.nTable = this;
 oSettings.oApi   = _that.internal;
@@ -94,14 +94,14 @@ _fnCompatOpts( oInit );
 
 if ( oInit.oLanguage )
 {
-    _fnLanguageCompat( oInit.oLanguage );
+	_fnLanguageCompat( oInit.oLanguage );
 }
 
 // If the length menu is given, but the init display length is not, use the length menu
 if ( oInit.aLengthMenu && ! oInit.iDisplayLength )
 {
-    oInit.iDisplayLength = $.isArray( oInit.aLengthMenu[0] ) ?
-        oInit.aLengthMenu[0][0] : oInit.aLengthMenu[0];
+	oInit.iDisplayLength = $.isArray( oInit.aLengthMenu[0] ) ?
+		oInit.aLengthMenu[0][0] : oInit.aLengthMenu[0];
 }
 
 // Apply the defaults and init options to make a single init object will all
@@ -111,52 +111,52 @@ oInit = _fnExtend( $.extend( true, {}, defaults ), oInit );
 
 // Map the initialisation options onto the settings object
 _fnMap( oSettings.oFeatures, oInit, [
-    "bPaginate",
-    "bLengthChange",
-    "bFilter",
+	"bPaginate",
+	"bLengthChange",
+	"bFilter",
     "bExclude",
-    "bSort",
-    "bSortMulti",
-    "bInfo",
-    "bProcessing",
-    "bAutoWidth",
-    "bSortClasses",
-    "bServerSide",
-    "bDeferRender"
+	"bSort",
+	"bSortMulti",
+	"bInfo",
+	"bProcessing",
+	"bAutoWidth",
+	"bSortClasses",
+	"bServerSide",
+	"bDeferRender"
 ] );
 _fnMap( oSettings, oInit, [
-    "asStripeClasses",
-    "ajax",
-    "fnServerData",
-    "fnFormatNumber",
-    "sServerMethod",
-    "aaSorting",
-    "aaSortingFixed",
-    "aLengthMenu",
-    "sPaginationType",
-    "sAjaxSource",
-    "sAjaxDataProp",
-    "iStateDuration",
-    "sDom",
-    "bSortCellsTop",
-    "iTabIndex",
-    "fnStateLoadCallback",
-    "fnStateSaveCallback",
-    "renderer",
-    "searchDelay",
-    "rowId",
-    [ "iCookieDuration", "iStateDuration" ], // backwards compat
-    [ "oSearch", "oPreviousSearch" ],
+	"asStripeClasses",
+	"ajax",
+	"fnServerData",
+	"fnFormatNumber",
+	"sServerMethod",
+	"aaSorting",
+	"aaSortingFixed",
+	"aLengthMenu",
+	"sPaginationType",
+	"sAjaxSource",
+	"sAjaxDataProp",
+	"iStateDuration",
+	"sDom",
+	"bSortCellsTop",
+	"iTabIndex",
+	"fnStateLoadCallback",
+	"fnStateSaveCallback",
+	"renderer",
+	"searchDelay",
+	"rowId",
+	[ "iCookieDuration", "iStateDuration" ], // backwards compat
+	[ "oSearch", "oPreviousSearch" ],
     [ "oExclude", "oPreviousExclude" ],
-    [ "aoSearchCols", "aoPreSearchCols" ],
-    [ "iDisplayLength", "_iDisplayLength" ],
-    [ "bJQueryUI", "bJUI" ]
+	[ "aoSearchCols", "aoPreSearchCols" ],
+	[ "iDisplayLength", "_iDisplayLength" ],
+	[ "bJQueryUI", "bJUI" ]
 ] );
 _fnMap( oSettings.oScroll, oInit, [
-    [ "sScrollX", "sX" ],
-    [ "sScrollXInner", "sXInner" ],
-    [ "sScrollY", "sY" ],
-    [ "bScrollCollapse", "bCollapse" ]
+	[ "sScrollX", "sX" ],
+	[ "sScrollXInner", "sXInner" ],
+	[ "sScrollY", "sY" ],
+	[ "bScrollCollapse", "bCollapse" ]
 ] );
 _fnMap( oSettings.oLanguage, oInit, "fnInfoCallback" );
 
@@ -186,24 +186,24 @@ if ( oInit.bJQueryUI )
 	/* Use the JUI classes object for display. You could clone the oStdClasses object if
 	 * you want to have multiple tables with multiple independent classes
 	 */
-    $.extend( oClasses, DataTable.ext.oJUIClasses, oInit.oClasses );
+	$.extend( oClasses, DataTable.ext.oJUIClasses, oInit.oClasses );
 
-    if ( oInit.sDom === defaults.sDom && defaults.sDom === "lfrtip" )
-    {
+	if ( oInit.sDom === defaults.sDom && defaults.sDom === "lfrtip" )
+	{
 		/* Set the DOM to use a layout suitable for jQuery UI's theming */
-        oSettings.sDom = '<"H"lfr>t<"F"ip>';
-    }
+		oSettings.sDom = '<"H"lfr>t<"F"ip>';
+	}
 
-    if ( ! oSettings.renderer ) {
-        oSettings.renderer = 'jqueryui';
-    }
-    else if ( $.isPlainObject( oSettings.renderer ) && ! oSettings.renderer.header ) {
-        oSettings.renderer.header = 'jqueryui';
-    }
+	if ( ! oSettings.renderer ) {
+		oSettings.renderer = 'jqueryui';
+	}
+	else if ( $.isPlainObject( oSettings.renderer ) && ! oSettings.renderer.header ) {
+		oSettings.renderer.header = 'jqueryui';
+	}
 }
 else
 {
-    $.extend( oClasses, DataTable.ext.classes, oInit.oClasses );
+	$.extend( oClasses, DataTable.ext.classes, oInit.oClasses );
 }
 $this.addClass( oClasses.sTable );
 
@@ -211,16 +211,16 @@ $this.addClass( oClasses.sTable );
 if ( oSettings.iInitDisplayStart === undefined )
 {
 	/* Display start point, taking into account the save saving */
-    oSettings.iInitDisplayStart = oInit.iDisplayStart;
-    oSettings._iDisplayStart = oInit.iDisplayStart;
+	oSettings.iInitDisplayStart = oInit.iDisplayStart;
+	oSettings._iDisplayStart = oInit.iDisplayStart;
 }
 
 if ( oInit.iDeferLoading !== null )
 {
-    oSettings.bDeferLoading = true;
-    var tmp = $.isArray( oInit.iDeferLoading );
-    oSettings._iRecordsDisplay = tmp ? oInit.iDeferLoading[0] : oInit.iDeferLoading;
-    oSettings._iRecordsTotal = tmp ? oInit.iDeferLoading[1] : oInit.iDeferLoading;
+	oSettings.bDeferLoading = true;
+	var tmp = $.isArray( oInit.iDeferLoading );
+	oSettings._iRecordsDisplay = tmp ? oInit.iDeferLoading[0] : oInit.iDeferLoading;
+	oSettings._iRecordsTotal = tmp ? oInit.iDeferLoading[1] : oInit.iDeferLoading;
 }
 
 /* Language definitions */
@@ -233,21 +233,21 @@ if ( oLanguage.sUrl )
 	 * get async to the remainder of this function we use bInitHandedOff to indicate that
 	 * _fnInitialise will be fired by the returned Ajax handler, rather than the constructor
 	 */
-    $.ajax( {
-        dataType: 'json',
-        url: oLanguage.sUrl,
-        success: function ( json ) {
-            _fnLanguageCompat( json );
-            _fnCamelToHungarian( defaults.oLanguage, json );
-            $.extend( true, oLanguage, json );
-            _fnInitialise( oSettings );
-        },
-        error: function () {
-            // Error occurred loading language file, continue on as best we can
-            _fnInitialise( oSettings );
-        }
-    } );
-    bInitHandedOff = true;
+	$.ajax( {
+		dataType: 'json',
+		url: oLanguage.sUrl,
+		success: function ( json ) {
+			_fnLanguageCompat( json );
+			_fnCamelToHungarian( defaults.oLanguage, json );
+			$.extend( true, oLanguage, json );
+			_fnInitialise( oSettings );
+		},
+		error: function () {
+			// Error occurred loading language file, continue on as best we can
+			_fnInitialise( oSettings );
+		}
+	} );
+	bInitHandedOff = true;
 }
 
 /*
@@ -255,20 +255,20 @@ if ( oLanguage.sUrl )
  */
 if ( oInit.asStripeClasses === null )
 {
-    oSettings.asStripeClasses =[
-        oClasses.sStripeOdd,
-        oClasses.sStripeEven
-    ];
+	oSettings.asStripeClasses =[
+		oClasses.sStripeOdd,
+		oClasses.sStripeEven
+	];
 }
 
 /* Remove row stripe classes if they are already on the table row */
 var stripeClasses = oSettings.asStripeClasses;
 var rowOne = $this.children('tbody').find('tr').eq(0);
 if ( $.inArray( true, $.map( stripeClasses, function(el, i) {
-        return rowOne.hasClass(el);
-    } ) ) !== -1 ) {
-    $('tbody tr', this).removeClass( stripeClasses.join(' ') );
-    oSettings.asDestroyStripes = stripeClasses.slice();
+	return rowOne.hasClass(el);
+} ) ) !== -1 ) {
+	$('tbody tr', this).removeClass( stripeClasses.join(' ') );
+	oSettings.asDestroyStripes = stripeClasses.slice();
 }
 
 /*
@@ -280,62 +280,62 @@ var aoColumnsInit;
 var nThead = this.getElementsByTagName('thead');
 if ( nThead.length !== 0 )
 {
-    _fnDetectHeader( oSettings.aoHeader, nThead[0] );
-    anThs = _fnGetUniqueThs( oSettings );
+	_fnDetectHeader( oSettings.aoHeader, nThead[0] );
+	anThs = _fnGetUniqueThs( oSettings );
 }
 
 /* If not given a column array, generate one with nulls */
 if ( oInit.aoColumns === null )
 {
-    aoColumnsInit = [];
-    for ( i=0, iLen=anThs.length ; i<iLen ; i++ )
-    {
-        aoColumnsInit.push( null );
-    }
+	aoColumnsInit = [];
+	for ( i=0, iLen=anThs.length ; i<iLen ; i++ )
+	{
+		aoColumnsInit.push( null );
+	}
 }
 else
 {
-    aoColumnsInit = oInit.aoColumns;
+	aoColumnsInit = oInit.aoColumns;
 }
 
 /* Add the columns */
 for ( i=0, iLen=aoColumnsInit.length ; i<iLen ; i++ )
 {
-    _fnAddColumn( oSettings, anThs ? anThs[i] : null );
+	_fnAddColumn( oSettings, anThs ? anThs[i] : null );
 }
 
 /* Apply the column definitions */
 _fnApplyColumnDefs( oSettings, oInit.aoColumnDefs, aoColumnsInit, function (iCol, oDef) {
-    _fnColumnOptions( oSettings, iCol, oDef );
+	_fnColumnOptions( oSettings, iCol, oDef );
 } );
 
 /* HTML5 attribute detection - build an mData object automatically if the
  * attributes are found
  */
 if ( rowOne.length ) {
-    var a = function ( cell, name ) {
-        return cell.getAttribute( 'data-'+name ) !== null ? name : null;
-    };
+	var a = function ( cell, name ) {
+		return cell.getAttribute( 'data-'+name ) !== null ? name : null;
+	};
 
-    $( rowOne[0] ).children('th, td').each( function (i, cell) {
-        var col = oSettings.aoColumns[i];
+	$( rowOne[0] ).children('th, td').each( function (i, cell) {
+		var col = oSettings.aoColumns[i];
 
-        if ( col.mData === i ) {
-            var sort = a( cell, 'sort' ) || a( cell, 'order' );
-            var filter = a( cell, 'filter' ) || a( cell, 'search' );
+		if ( col.mData === i ) {
+			var sort = a( cell, 'sort' ) || a( cell, 'order' );
+			var filter = a( cell, 'filter' ) || a( cell, 'search' );
 
-            if ( sort !== null || filter !== null ) {
-                col.mData = {
-                    _:      i+'.display',
-                    sort:   sort !== null   ? i+'.@data-'+sort   : undefined,
-                    type:   sort !== null   ? i+'.@data-'+sort   : undefined,
-                    filter: filter !== null ? i+'.@data-'+filter : undefined
-                };
+			if ( sort !== null || filter !== null ) {
+				col.mData = {
+					_:      i+'.display',
+					sort:   sort !== null   ? i+'.@data-'+sort   : undefined,
+					type:   sort !== null   ? i+'.@data-'+sort   : undefined,
+					filter: filter !== null ? i+'.@data-'+filter : undefined
+				};
 
-                _fnColumnOptions( oSettings, i );
-            }
-        }
-    } );
+				_fnColumnOptions( oSettings, i );
+			}
+		}
+	} );
 }
 
 var features = oSettings.oFeatures;
@@ -345,41 +345,41 @@ var loadedInit = function () {
 	 * @todo For modularisation (1.11) this needs to do into a sort start up handler
 	 */
 
-    // If aaSorting is not defined, then we use the first indicator in asSorting
-    // in case that has been altered, so the default sort reflects that option
-    if ( oInit.aaSorting === undefined ) {
-        var sorting = oSettings.aaSorting;
-        for ( i=0, iLen=sorting.length ; i<iLen ; i++ ) {
-            sorting[i][1] = oSettings.aoColumns[ i ].asSorting[0];
-        }
-    }
+	// If aaSorting is not defined, then we use the first indicator in asSorting
+	// in case that has been altered, so the default sort reflects that option
+	if ( oInit.aaSorting === undefined ) {
+		var sorting = oSettings.aaSorting;
+		for ( i=0, iLen=sorting.length ; i<iLen ; i++ ) {
+			sorting[i][1] = oSettings.aoColumns[ i ].asSorting[0];
+		}
+	}
 
 	/* Do a first pass on the sorting classes (allows any size changes to be taken into
 	 * account, and also will apply sorting disabled classes if disabled
 	 */
-    _fnSortingClasses( oSettings );
+	_fnSortingClasses( oSettings );
 
-    if ( features.bSort ) {
-        _fnCallbackReg( oSettings, 'aoDrawCallback', function () {
-            if ( oSettings.bSorted ) {
-                var aSort = _fnSortFlatten( oSettings );
-                var sortedColumns = {};
+	if ( features.bSort ) {
+		_fnCallbackReg( oSettings, 'aoDrawCallback', function () {
+			if ( oSettings.bSorted ) {
+				var aSort = _fnSortFlatten( oSettings );
+				var sortedColumns = {};
 
-                $.each( aSort, function (i, val) {
-                    sortedColumns[ val.src ] = val.dir;
-                } );
+				$.each( aSort, function (i, val) {
+					sortedColumns[ val.src ] = val.dir;
+				} );
 
-                _fnCallbackFire( oSettings, null, 'order', [oSettings, aSort, sortedColumns] );
-                _fnSortAria( oSettings );
-            }
-        } );
-    }
+				_fnCallbackFire( oSettings, null, 'order', [oSettings, aSort, sortedColumns] );
+				_fnSortAria( oSettings );
+			}
+		} );
+	}
 
-    _fnCallbackReg( oSettings, 'aoDrawCallback', function () {
-        if ( oSettings.bSorted || _fnDataSource( oSettings ) === 'ssp' || features.bDeferRender ) {
-            _fnSortingClasses( oSettings );
-        }
-    }, 'sc' );
+	_fnCallbackReg( oSettings, 'aoDrawCallback', function () {
+		if ( oSettings.bSorted || _fnDataSource( oSettings ) === 'ssp' || features.bDeferRender ) {
+			_fnSortingClasses( oSettings );
+		}
+	}, 'sc' );
 
 
 	/*
@@ -387,74 +387,74 @@ var loadedInit = function () {
 	 * Cache the header, body and footer as required, creating them if needed
 	 */
 
-    // Work around for Webkit bug 83867 - store the caption-side before removing from doc
-    var captions = $this.children('caption').each( function () {
-        this._captionSide = $(this).css('caption-side');
-    } );
+	// Work around for Webkit bug 83867 - store the caption-side before removing from doc
+	var captions = $this.children('caption').each( function () {
+		this._captionSide = $(this).css('caption-side');
+	} );
 
-    var thead = $this.children('thead');
-    if ( thead.length === 0 ) {
-        thead = $('<thead/>').appendTo($this);
-    }
-    oSettings.nTHead = thead[0];
+	var thead = $this.children('thead');
+	if ( thead.length === 0 ) {
+		thead = $('<thead/>').appendTo($this);
+	}
+	oSettings.nTHead = thead[0];
 
-    var tbody = $this.children('tbody');
-    if ( tbody.length === 0 ) {
-        tbody = $('<tbody/>').appendTo($this);
-    }
-    oSettings.nTBody = tbody[0];
+	var tbody = $this.children('tbody');
+	if ( tbody.length === 0 ) {
+		tbody = $('<tbody/>').appendTo($this);
+	}
+	oSettings.nTBody = tbody[0];
 
-    var tfoot = $this.children('tfoot');
-    if ( tfoot.length === 0 && captions.length > 0 && (oSettings.oScroll.sX !== "" || oSettings.oScroll.sY !== "") ) {
-        // If we are a scrolling table, and no footer has been given, then we need to create
-        // a tfoot element for the caption element to be appended to
-        tfoot = $('<tfoot/>').appendTo($this);
-    }
+	var tfoot = $this.children('tfoot');
+	if ( tfoot.length === 0 && captions.length > 0 && (oSettings.oScroll.sX !== "" || oSettings.oScroll.sY !== "") ) {
+		// If we are a scrolling table, and no footer has been given, then we need to create
+		// a tfoot element for the caption element to be appended to
+		tfoot = $('<tfoot/>').appendTo($this);
+	}
 
-    if ( tfoot.length === 0 || tfoot.children().length === 0 ) {
-        $this.addClass( oClasses.sNoFooter );
-    }
-    else if ( tfoot.length > 0 ) {
-        oSettings.nTFoot = tfoot[0];
-        _fnDetectHeader( oSettings.aoFooter, oSettings.nTFoot );
-    }
+	if ( tfoot.length === 0 || tfoot.children().length === 0 ) {
+		$this.addClass( oClasses.sNoFooter );
+	}
+	else if ( tfoot.length > 0 ) {
+		oSettings.nTFoot = tfoot[0];
+		_fnDetectHeader( oSettings.aoFooter, oSettings.nTFoot );
+	}
 
 	/* Check if there is data passing into the constructor */
-    if ( oInit.aaData ) {
-        for ( i=0 ; i<oInit.aaData.length ; i++ ) {
-            _fnAddData( oSettings, oInit.aaData[ i ] );
-        }
-    }
-    else if ( oSettings.bDeferLoading || _fnDataSource( oSettings ) == 'dom' ) {
+	if ( oInit.aaData ) {
+		for ( i=0 ; i<oInit.aaData.length ; i++ ) {
+			_fnAddData( oSettings, oInit.aaData[ i ] );
+		}
+	}
+	else if ( oSettings.bDeferLoading || _fnDataSource( oSettings ) == 'dom' ) {
 		/* Grab the data from the page - only do this when deferred loading or no Ajax
 		 * source since there is no point in reading the DOM data if we are then going
 		 * to replace it with Ajax data
 		 */
-        _fnAddTr( oSettings, $(oSettings.nTBody).children('tr') );
-    }
+		_fnAddTr( oSettings, $(oSettings.nTBody).children('tr') );
+	}
 
 	/* Copy the data index array */
-    oSettings.aiDisplay = oSettings.aiDisplayMaster.slice();
+	oSettings.aiDisplay = oSettings.aiDisplayMaster.slice();
 
 	/* Initialisation complete - table can be drawn */
-    oSettings.bInitialised = true;
+	oSettings.bInitialised = true;
 
 	/* Check if we need to initialise the table (it might not have been handed off to the
 	 * language processor)
 	 */
-    if ( bInitHandedOff === false ) {
-        _fnInitialise( oSettings );
-    }
+	if ( bInitHandedOff === false ) {
+		_fnInitialise( oSettings );
+	}
 };
 
 /* Must be done after everything which can be overridden by the state saving! */
 if ( oInit.bStateSave )
 {
-    features.bStateSave = true;
-    _fnCallbackReg( oSettings, 'aoDrawCallback', _fnSaveState, 'state_save' );
-    _fnLoadState( oSettings, oInit, loadedInit );
+	features.bStateSave = true;
+	_fnCallbackReg( oSettings, 'aoDrawCallback', _fnSaveState, 'state_save' );
+	_fnLoadState( oSettings, oInit, loadedInit );
 }
 else {
-    loadedInit();
+	loadedInit();
 }
 

--- a/js/core/core.constructor.js
+++ b/js/core/core.constructor.js
@@ -9,8 +9,8 @@ var $this = $(this);
 /* Sanity check */
 if ( this.nodeName.toLowerCase() != 'table' )
 {
-	_fnLog( null, 0, 'Non-table node initialisation ('+this.nodeName+')', 2 );
-	return;
+    _fnLog( null, 0, 'Non-table node initialisation ('+this.nodeName+')', 2 );
+    return;
 }
 
 /* Backwards compatibility for the defaults */
@@ -30,54 +30,54 @@ _fnCamelToHungarian( defaults, $.extend( oInit, $this.data() ) );
 var allSettings = DataTable.settings;
 for ( i=0, iLen=allSettings.length ; i<iLen ; i++ )
 {
-	var s = allSettings[i];
+    var s = allSettings[i];
 
 	/* Base check on table node */
-	if ( s.nTable == this || s.nTHead.parentNode == this || (s.nTFoot && s.nTFoot.parentNode == this) )
-	{
-		var bRetrieve = oInit.bRetrieve !== undefined ? oInit.bRetrieve : defaults.bRetrieve;
-		var bDestroy = oInit.bDestroy !== undefined ? oInit.bDestroy : defaults.bDestroy;
+    if ( s.nTable == this || s.nTHead.parentNode == this || (s.nTFoot && s.nTFoot.parentNode == this) )
+    {
+        var bRetrieve = oInit.bRetrieve !== undefined ? oInit.bRetrieve : defaults.bRetrieve;
+        var bDestroy = oInit.bDestroy !== undefined ? oInit.bDestroy : defaults.bDestroy;
 
-		if ( emptyInit || bRetrieve )
-		{
-			return s.oInstance;
-		}
-		else if ( bDestroy )
-		{
-			s.oInstance.fnDestroy();
-			break;
-		}
-		else
-		{
-			_fnLog( s, 0, 'Cannot reinitialise DataTable', 3 );
-			return;
-		}
-	}
+        if ( emptyInit || bRetrieve )
+        {
+            return s.oInstance;
+        }
+        else if ( bDestroy )
+        {
+            s.oInstance.fnDestroy();
+            break;
+        }
+        else
+        {
+            _fnLog( s, 0, 'Cannot reinitialise DataTable', 3 );
+            return;
+        }
+    }
 
 	/* If the element we are initialising has the same ID as a table which was previously
 	 * initialised, but the table nodes don't match (from before) then we destroy the old
 	 * instance by simply deleting it. This is under the assumption that the table has been
 	 * destroyed by other methods. Anyone using non-id selectors will need to do this manually
 	 */
-	if ( s.sTableId == this.id )
-	{
-		allSettings.splice( i, 1 );
-		break;
-	}
+    if ( s.sTableId == this.id )
+    {
+        allSettings.splice( i, 1 );
+        break;
+    }
 }
 
 /* Ensure the table has an ID - required for accessibility */
 if ( sId === null || sId === "" )
 {
-	sId = "DataTables_Table_"+(DataTable.ext._unique++);
-	this.id = sId;
+    sId = "DataTables_Table_"+(DataTable.ext._unique++);
+    this.id = sId;
 }
 
 /* Create the settings object for this table and set some of the default parameters */
 var oSettings = $.extend( true, {}, DataTable.models.oSettings, {
-	"sDestroyWidth": $this[0].style.width,
-	"sInstance":     sId,
-	"sTableId":      sId
+    "sDestroyWidth": $this[0].style.width,
+    "sInstance":     sId,
+    "sTableId":      sId
 } );
 oSettings.nTable = this;
 oSettings.oApi   = _that.internal;
@@ -94,14 +94,14 @@ _fnCompatOpts( oInit );
 
 if ( oInit.oLanguage )
 {
-	_fnLanguageCompat( oInit.oLanguage );
+    _fnLanguageCompat( oInit.oLanguage );
 }
 
 // If the length menu is given, but the init display length is not, use the length menu
 if ( oInit.aLengthMenu && ! oInit.iDisplayLength )
 {
-	oInit.iDisplayLength = $.isArray( oInit.aLengthMenu[0] ) ?
-		oInit.aLengthMenu[0][0] : oInit.aLengthMenu[0];
+    oInit.iDisplayLength = $.isArray( oInit.aLengthMenu[0] ) ?
+        oInit.aLengthMenu[0][0] : oInit.aLengthMenu[0];
 }
 
 // Apply the defaults and init options to make a single init object will all
@@ -111,50 +111,52 @@ oInit = _fnExtend( $.extend( true, {}, defaults ), oInit );
 
 // Map the initialisation options onto the settings object
 _fnMap( oSettings.oFeatures, oInit, [
-	"bPaginate",
-	"bLengthChange",
-	"bFilter",
-	"bSort",
-	"bSortMulti",
-	"bInfo",
-	"bProcessing",
-	"bAutoWidth",
-	"bSortClasses",
-	"bServerSide",
-	"bDeferRender"
+    "bPaginate",
+    "bLengthChange",
+    "bFilter",
+    "bExclude",
+    "bSort",
+    "bSortMulti",
+    "bInfo",
+    "bProcessing",
+    "bAutoWidth",
+    "bSortClasses",
+    "bServerSide",
+    "bDeferRender"
 ] );
 _fnMap( oSettings, oInit, [
-	"asStripeClasses",
-	"ajax",
-	"fnServerData",
-	"fnFormatNumber",
-	"sServerMethod",
-	"aaSorting",
-	"aaSortingFixed",
-	"aLengthMenu",
-	"sPaginationType",
-	"sAjaxSource",
-	"sAjaxDataProp",
-	"iStateDuration",
-	"sDom",
-	"bSortCellsTop",
-	"iTabIndex",
-	"fnStateLoadCallback",
-	"fnStateSaveCallback",
-	"renderer",
-	"searchDelay",
-	"rowId",
-	[ "iCookieDuration", "iStateDuration" ], // backwards compat
-	[ "oSearch", "oPreviousSearch" ],
-	[ "aoSearchCols", "aoPreSearchCols" ],
-	[ "iDisplayLength", "_iDisplayLength" ],
-	[ "bJQueryUI", "bJUI" ]
+    "asStripeClasses",
+    "ajax",
+    "fnServerData",
+    "fnFormatNumber",
+    "sServerMethod",
+    "aaSorting",
+    "aaSortingFixed",
+    "aLengthMenu",
+    "sPaginationType",
+    "sAjaxSource",
+    "sAjaxDataProp",
+    "iStateDuration",
+    "sDom",
+    "bSortCellsTop",
+    "iTabIndex",
+    "fnStateLoadCallback",
+    "fnStateSaveCallback",
+    "renderer",
+    "searchDelay",
+    "rowId",
+    [ "iCookieDuration", "iStateDuration" ], // backwards compat
+    [ "oSearch", "oPreviousSearch" ],
+    [ "oExclude", "oPreviousExclude" ],
+    [ "aoSearchCols", "aoPreSearchCols" ],
+    [ "iDisplayLength", "_iDisplayLength" ],
+    [ "bJQueryUI", "bJUI" ]
 ] );
 _fnMap( oSettings.oScroll, oInit, [
-	[ "sScrollX", "sX" ],
-	[ "sScrollXInner", "sXInner" ],
-	[ "sScrollY", "sY" ],
-	[ "bScrollCollapse", "bCollapse" ]
+    [ "sScrollX", "sX" ],
+    [ "sScrollXInner", "sXInner" ],
+    [ "sScrollY", "sY" ],
+    [ "bScrollCollapse", "bCollapse" ]
 ] );
 _fnMap( oSettings.oLanguage, oInit, "fnInfoCallback" );
 
@@ -184,24 +186,24 @@ if ( oInit.bJQueryUI )
 	/* Use the JUI classes object for display. You could clone the oStdClasses object if
 	 * you want to have multiple tables with multiple independent classes
 	 */
-	$.extend( oClasses, DataTable.ext.oJUIClasses, oInit.oClasses );
+    $.extend( oClasses, DataTable.ext.oJUIClasses, oInit.oClasses );
 
-	if ( oInit.sDom === defaults.sDom && defaults.sDom === "lfrtip" )
-	{
+    if ( oInit.sDom === defaults.sDom && defaults.sDom === "lfrtip" )
+    {
 		/* Set the DOM to use a layout suitable for jQuery UI's theming */
-		oSettings.sDom = '<"H"lfr>t<"F"ip>';
-	}
+        oSettings.sDom = '<"H"lfr>t<"F"ip>';
+    }
 
-	if ( ! oSettings.renderer ) {
-		oSettings.renderer = 'jqueryui';
-	}
-	else if ( $.isPlainObject( oSettings.renderer ) && ! oSettings.renderer.header ) {
-		oSettings.renderer.header = 'jqueryui';
-	}
+    if ( ! oSettings.renderer ) {
+        oSettings.renderer = 'jqueryui';
+    }
+    else if ( $.isPlainObject( oSettings.renderer ) && ! oSettings.renderer.header ) {
+        oSettings.renderer.header = 'jqueryui';
+    }
 }
 else
 {
-	$.extend( oClasses, DataTable.ext.classes, oInit.oClasses );
+    $.extend( oClasses, DataTable.ext.classes, oInit.oClasses );
 }
 $this.addClass( oClasses.sTable );
 
@@ -209,16 +211,16 @@ $this.addClass( oClasses.sTable );
 if ( oSettings.iInitDisplayStart === undefined )
 {
 	/* Display start point, taking into account the save saving */
-	oSettings.iInitDisplayStart = oInit.iDisplayStart;
-	oSettings._iDisplayStart = oInit.iDisplayStart;
+    oSettings.iInitDisplayStart = oInit.iDisplayStart;
+    oSettings._iDisplayStart = oInit.iDisplayStart;
 }
 
 if ( oInit.iDeferLoading !== null )
 {
-	oSettings.bDeferLoading = true;
-	var tmp = $.isArray( oInit.iDeferLoading );
-	oSettings._iRecordsDisplay = tmp ? oInit.iDeferLoading[0] : oInit.iDeferLoading;
-	oSettings._iRecordsTotal = tmp ? oInit.iDeferLoading[1] : oInit.iDeferLoading;
+    oSettings.bDeferLoading = true;
+    var tmp = $.isArray( oInit.iDeferLoading );
+    oSettings._iRecordsDisplay = tmp ? oInit.iDeferLoading[0] : oInit.iDeferLoading;
+    oSettings._iRecordsTotal = tmp ? oInit.iDeferLoading[1] : oInit.iDeferLoading;
 }
 
 /* Language definitions */
@@ -231,21 +233,21 @@ if ( oLanguage.sUrl )
 	 * get async to the remainder of this function we use bInitHandedOff to indicate that
 	 * _fnInitialise will be fired by the returned Ajax handler, rather than the constructor
 	 */
-	$.ajax( {
-		dataType: 'json',
-		url: oLanguage.sUrl,
-		success: function ( json ) {
-			_fnLanguageCompat( json );
-			_fnCamelToHungarian( defaults.oLanguage, json );
-			$.extend( true, oLanguage, json );
-			_fnInitialise( oSettings );
-		},
-		error: function () {
-			// Error occurred loading language file, continue on as best we can
-			_fnInitialise( oSettings );
-		}
-	} );
-	bInitHandedOff = true;
+    $.ajax( {
+        dataType: 'json',
+        url: oLanguage.sUrl,
+        success: function ( json ) {
+            _fnLanguageCompat( json );
+            _fnCamelToHungarian( defaults.oLanguage, json );
+            $.extend( true, oLanguage, json );
+            _fnInitialise( oSettings );
+        },
+        error: function () {
+            // Error occurred loading language file, continue on as best we can
+            _fnInitialise( oSettings );
+        }
+    } );
+    bInitHandedOff = true;
 }
 
 /*
@@ -253,20 +255,20 @@ if ( oLanguage.sUrl )
  */
 if ( oInit.asStripeClasses === null )
 {
-	oSettings.asStripeClasses =[
-		oClasses.sStripeOdd,
-		oClasses.sStripeEven
-	];
+    oSettings.asStripeClasses =[
+        oClasses.sStripeOdd,
+        oClasses.sStripeEven
+    ];
 }
 
 /* Remove row stripe classes if they are already on the table row */
 var stripeClasses = oSettings.asStripeClasses;
 var rowOne = $this.children('tbody').find('tr').eq(0);
 if ( $.inArray( true, $.map( stripeClasses, function(el, i) {
-	return rowOne.hasClass(el);
-} ) ) !== -1 ) {
-	$('tbody tr', this).removeClass( stripeClasses.join(' ') );
-	oSettings.asDestroyStripes = stripeClasses.slice();
+        return rowOne.hasClass(el);
+    } ) ) !== -1 ) {
+    $('tbody tr', this).removeClass( stripeClasses.join(' ') );
+    oSettings.asDestroyStripes = stripeClasses.slice();
 }
 
 /*
@@ -278,62 +280,62 @@ var aoColumnsInit;
 var nThead = this.getElementsByTagName('thead');
 if ( nThead.length !== 0 )
 {
-	_fnDetectHeader( oSettings.aoHeader, nThead[0] );
-	anThs = _fnGetUniqueThs( oSettings );
+    _fnDetectHeader( oSettings.aoHeader, nThead[0] );
+    anThs = _fnGetUniqueThs( oSettings );
 }
 
 /* If not given a column array, generate one with nulls */
 if ( oInit.aoColumns === null )
 {
-	aoColumnsInit = [];
-	for ( i=0, iLen=anThs.length ; i<iLen ; i++ )
-	{
-		aoColumnsInit.push( null );
-	}
+    aoColumnsInit = [];
+    for ( i=0, iLen=anThs.length ; i<iLen ; i++ )
+    {
+        aoColumnsInit.push( null );
+    }
 }
 else
 {
-	aoColumnsInit = oInit.aoColumns;
+    aoColumnsInit = oInit.aoColumns;
 }
 
 /* Add the columns */
 for ( i=0, iLen=aoColumnsInit.length ; i<iLen ; i++ )
 {
-	_fnAddColumn( oSettings, anThs ? anThs[i] : null );
+    _fnAddColumn( oSettings, anThs ? anThs[i] : null );
 }
 
 /* Apply the column definitions */
 _fnApplyColumnDefs( oSettings, oInit.aoColumnDefs, aoColumnsInit, function (iCol, oDef) {
-	_fnColumnOptions( oSettings, iCol, oDef );
+    _fnColumnOptions( oSettings, iCol, oDef );
 } );
 
 /* HTML5 attribute detection - build an mData object automatically if the
  * attributes are found
  */
 if ( rowOne.length ) {
-	var a = function ( cell, name ) {
-		return cell.getAttribute( 'data-'+name ) !== null ? name : null;
-	};
+    var a = function ( cell, name ) {
+        return cell.getAttribute( 'data-'+name ) !== null ? name : null;
+    };
 
-	$( rowOne[0] ).children('th, td').each( function (i, cell) {
-		var col = oSettings.aoColumns[i];
+    $( rowOne[0] ).children('th, td').each( function (i, cell) {
+        var col = oSettings.aoColumns[i];
 
-		if ( col.mData === i ) {
-			var sort = a( cell, 'sort' ) || a( cell, 'order' );
-			var filter = a( cell, 'filter' ) || a( cell, 'search' );
+        if ( col.mData === i ) {
+            var sort = a( cell, 'sort' ) || a( cell, 'order' );
+            var filter = a( cell, 'filter' ) || a( cell, 'search' );
 
-			if ( sort !== null || filter !== null ) {
-				col.mData = {
-					_:      i+'.display',
-					sort:   sort !== null   ? i+'.@data-'+sort   : undefined,
-					type:   sort !== null   ? i+'.@data-'+sort   : undefined,
-					filter: filter !== null ? i+'.@data-'+filter : undefined
-				};
+            if ( sort !== null || filter !== null ) {
+                col.mData = {
+                    _:      i+'.display',
+                    sort:   sort !== null   ? i+'.@data-'+sort   : undefined,
+                    type:   sort !== null   ? i+'.@data-'+sort   : undefined,
+                    filter: filter !== null ? i+'.@data-'+filter : undefined
+                };
 
-				_fnColumnOptions( oSettings, i );
-			}
-		}
-	} );
+                _fnColumnOptions( oSettings, i );
+            }
+        }
+    } );
 }
 
 var features = oSettings.oFeatures;
@@ -343,41 +345,41 @@ var loadedInit = function () {
 	 * @todo For modularisation (1.11) this needs to do into a sort start up handler
 	 */
 
-	// If aaSorting is not defined, then we use the first indicator in asSorting
-	// in case that has been altered, so the default sort reflects that option
-	if ( oInit.aaSorting === undefined ) {
-		var sorting = oSettings.aaSorting;
-		for ( i=0, iLen=sorting.length ; i<iLen ; i++ ) {
-			sorting[i][1] = oSettings.aoColumns[ i ].asSorting[0];
-		}
-	}
+    // If aaSorting is not defined, then we use the first indicator in asSorting
+    // in case that has been altered, so the default sort reflects that option
+    if ( oInit.aaSorting === undefined ) {
+        var sorting = oSettings.aaSorting;
+        for ( i=0, iLen=sorting.length ; i<iLen ; i++ ) {
+            sorting[i][1] = oSettings.aoColumns[ i ].asSorting[0];
+        }
+    }
 
 	/* Do a first pass on the sorting classes (allows any size changes to be taken into
 	 * account, and also will apply sorting disabled classes if disabled
 	 */
-	_fnSortingClasses( oSettings );
+    _fnSortingClasses( oSettings );
 
-	if ( features.bSort ) {
-		_fnCallbackReg( oSettings, 'aoDrawCallback', function () {
-			if ( oSettings.bSorted ) {
-				var aSort = _fnSortFlatten( oSettings );
-				var sortedColumns = {};
+    if ( features.bSort ) {
+        _fnCallbackReg( oSettings, 'aoDrawCallback', function () {
+            if ( oSettings.bSorted ) {
+                var aSort = _fnSortFlatten( oSettings );
+                var sortedColumns = {};
 
-				$.each( aSort, function (i, val) {
-					sortedColumns[ val.src ] = val.dir;
-				} );
+                $.each( aSort, function (i, val) {
+                    sortedColumns[ val.src ] = val.dir;
+                } );
 
-				_fnCallbackFire( oSettings, null, 'order', [oSettings, aSort, sortedColumns] );
-				_fnSortAria( oSettings );
-			}
-		} );
-	}
+                _fnCallbackFire( oSettings, null, 'order', [oSettings, aSort, sortedColumns] );
+                _fnSortAria( oSettings );
+            }
+        } );
+    }
 
-	_fnCallbackReg( oSettings, 'aoDrawCallback', function () {
-		if ( oSettings.bSorted || _fnDataSource( oSettings ) === 'ssp' || features.bDeferRender ) {
-			_fnSortingClasses( oSettings );
-		}
-	}, 'sc' );
+    _fnCallbackReg( oSettings, 'aoDrawCallback', function () {
+        if ( oSettings.bSorted || _fnDataSource( oSettings ) === 'ssp' || features.bDeferRender ) {
+            _fnSortingClasses( oSettings );
+        }
+    }, 'sc' );
 
 
 	/*
@@ -385,74 +387,74 @@ var loadedInit = function () {
 	 * Cache the header, body and footer as required, creating them if needed
 	 */
 
-	// Work around for Webkit bug 83867 - store the caption-side before removing from doc
-	var captions = $this.children('caption').each( function () {
-		this._captionSide = $(this).css('caption-side');
-	} );
+    // Work around for Webkit bug 83867 - store the caption-side before removing from doc
+    var captions = $this.children('caption').each( function () {
+        this._captionSide = $(this).css('caption-side');
+    } );
 
-	var thead = $this.children('thead');
-	if ( thead.length === 0 ) {
-		thead = $('<thead/>').appendTo($this);
-	}
-	oSettings.nTHead = thead[0];
+    var thead = $this.children('thead');
+    if ( thead.length === 0 ) {
+        thead = $('<thead/>').appendTo($this);
+    }
+    oSettings.nTHead = thead[0];
 
-	var tbody = $this.children('tbody');
-	if ( tbody.length === 0 ) {
-		tbody = $('<tbody/>').appendTo($this);
-	}
-	oSettings.nTBody = tbody[0];
+    var tbody = $this.children('tbody');
+    if ( tbody.length === 0 ) {
+        tbody = $('<tbody/>').appendTo($this);
+    }
+    oSettings.nTBody = tbody[0];
 
-	var tfoot = $this.children('tfoot');
-	if ( tfoot.length === 0 && captions.length > 0 && (oSettings.oScroll.sX !== "" || oSettings.oScroll.sY !== "") ) {
-		// If we are a scrolling table, and no footer has been given, then we need to create
-		// a tfoot element for the caption element to be appended to
-		tfoot = $('<tfoot/>').appendTo($this);
-	}
+    var tfoot = $this.children('tfoot');
+    if ( tfoot.length === 0 && captions.length > 0 && (oSettings.oScroll.sX !== "" || oSettings.oScroll.sY !== "") ) {
+        // If we are a scrolling table, and no footer has been given, then we need to create
+        // a tfoot element for the caption element to be appended to
+        tfoot = $('<tfoot/>').appendTo($this);
+    }
 
-	if ( tfoot.length === 0 || tfoot.children().length === 0 ) {
-		$this.addClass( oClasses.sNoFooter );
-	}
-	else if ( tfoot.length > 0 ) {
-		oSettings.nTFoot = tfoot[0];
-		_fnDetectHeader( oSettings.aoFooter, oSettings.nTFoot );
-	}
+    if ( tfoot.length === 0 || tfoot.children().length === 0 ) {
+        $this.addClass( oClasses.sNoFooter );
+    }
+    else if ( tfoot.length > 0 ) {
+        oSettings.nTFoot = tfoot[0];
+        _fnDetectHeader( oSettings.aoFooter, oSettings.nTFoot );
+    }
 
 	/* Check if there is data passing into the constructor */
-	if ( oInit.aaData ) {
-		for ( i=0 ; i<oInit.aaData.length ; i++ ) {
-			_fnAddData( oSettings, oInit.aaData[ i ] );
-		}
-	}
-	else if ( oSettings.bDeferLoading || _fnDataSource( oSettings ) == 'dom' ) {
+    if ( oInit.aaData ) {
+        for ( i=0 ; i<oInit.aaData.length ; i++ ) {
+            _fnAddData( oSettings, oInit.aaData[ i ] );
+        }
+    }
+    else if ( oSettings.bDeferLoading || _fnDataSource( oSettings ) == 'dom' ) {
 		/* Grab the data from the page - only do this when deferred loading or no Ajax
 		 * source since there is no point in reading the DOM data if we are then going
 		 * to replace it with Ajax data
 		 */
-		_fnAddTr( oSettings, $(oSettings.nTBody).children('tr') );
-	}
+        _fnAddTr( oSettings, $(oSettings.nTBody).children('tr') );
+    }
 
 	/* Copy the data index array */
-	oSettings.aiDisplay = oSettings.aiDisplayMaster.slice();
+    oSettings.aiDisplay = oSettings.aiDisplayMaster.slice();
 
 	/* Initialisation complete - table can be drawn */
-	oSettings.bInitialised = true;
+    oSettings.bInitialised = true;
 
 	/* Check if we need to initialise the table (it might not have been handed off to the
 	 * language processor)
 	 */
-	if ( bInitHandedOff === false ) {
-		_fnInitialise( oSettings );
-	}
+    if ( bInitHandedOff === false ) {
+        _fnInitialise( oSettings );
+    }
 };
 
 /* Must be done after everything which can be overridden by the state saving! */
 if ( oInit.bStateSave )
 {
-	features.bStateSave = true;
-	_fnCallbackReg( oSettings, 'aoDrawCallback', _fnSaveState, 'state_save' );
-	_fnLoadState( oSettings, oInit, loadedInit );
+    features.bStateSave = true;
+    _fnCallbackReg( oSettings, 'aoDrawCallback', _fnSaveState, 'state_save' );
+    _fnLoadState( oSettings, oInit, loadedInit );
 }
 else {
-	loadedInit();
+    loadedInit();
 }
 

--- a/js/core/core.draw.js
+++ b/js/core/core.draw.js
@@ -10,78 +10,78 @@
  */
 function _fnCreateTr ( oSettings, iRow, nTrIn, anTds )
 {
-	var
-		row = oSettings.aoData[iRow],
-		rowData = row._aData,
-		cells = [],
-		nTr, nTd, oCol,
-		i, iLen;
+    var
+        row = oSettings.aoData[iRow],
+        rowData = row._aData,
+        cells = [],
+        nTr, nTd, oCol,
+        i, iLen;
 
-	if ( row.nTr === null )
-	{
-		nTr = nTrIn || document.createElement('tr');
+    if ( row.nTr === null )
+    {
+        nTr = nTrIn || document.createElement('tr');
 
-		row.nTr = nTr;
-		row.anCells = cells;
+        row.nTr = nTr;
+        row.anCells = cells;
 
 		/* Use a private property on the node to allow reserve mapping from the node
 		 * to the aoData array for fast look up
 		 */
-		nTr._DT_RowIndex = iRow;
+        nTr._DT_RowIndex = iRow;
 
 		/* Special parameters can be given by the data source to be used on the row */
-		_fnRowAttributes( oSettings, row );
+        _fnRowAttributes( oSettings, row );
 
 		/* Process each column */
-		for ( i=0, iLen=oSettings.aoColumns.length ; i<iLen ; i++ )
-		{
-			oCol = oSettings.aoColumns[i];
+        for ( i=0, iLen=oSettings.aoColumns.length ; i<iLen ; i++ )
+        {
+            oCol = oSettings.aoColumns[i];
 
-			nTd = nTrIn ? anTds[i] : document.createElement( oCol.sCellType );
-			nTd._DT_CellIndex = {
-				row: iRow,
-				column: i
-			};
-			
-			cells.push( nTd );
+            nTd = nTrIn ? anTds[i] : document.createElement( oCol.sCellType );
+            nTd._DT_CellIndex = {
+                row: iRow,
+                column: i
+            };
 
-			// Need to create the HTML if new, or if a rendering function is defined
-			if ( (!nTrIn || oCol.mRender || oCol.mData !== i) &&
-				 (!$.isPlainObject(oCol.mData) || oCol.mData._ !== i+'.display')
-			) {
-				nTd.innerHTML = _fnGetCellData( oSettings, iRow, i, 'display' );
-			}
+            cells.push( nTd );
+
+            // Need to create the HTML if new, or if a rendering function is defined
+            if ( (!nTrIn || oCol.mRender || oCol.mData !== i) &&
+                (!$.isPlainObject(oCol.mData) || oCol.mData._ !== i+'.display')
+            ) {
+                nTd.innerHTML = _fnGetCellData( oSettings, iRow, i, 'display' );
+            }
 
 			/* Add user defined class */
-			if ( oCol.sClass )
-			{
-				nTd.className += ' '+oCol.sClass;
-			}
+            if ( oCol.sClass )
+            {
+                nTd.className += ' '+oCol.sClass;
+            }
 
-			// Visibility - add or remove as required
-			if ( oCol.bVisible && ! nTrIn )
-			{
-				nTr.appendChild( nTd );
-			}
-			else if ( ! oCol.bVisible && nTrIn )
-			{
-				nTd.parentNode.removeChild( nTd );
-			}
+            // Visibility - add or remove as required
+            if ( oCol.bVisible && ! nTrIn )
+            {
+                nTr.appendChild( nTd );
+            }
+            else if ( ! oCol.bVisible && nTrIn )
+            {
+                nTd.parentNode.removeChild( nTd );
+            }
 
-			if ( oCol.fnCreatedCell )
-			{
-				oCol.fnCreatedCell.call( oSettings.oInstance,
-					nTd, _fnGetCellData( oSettings, iRow, i ), rowData, iRow, i
-				);
-			}
-		}
+            if ( oCol.fnCreatedCell )
+            {
+                oCol.fnCreatedCell.call( oSettings.oInstance,
+                    nTd, _fnGetCellData( oSettings, iRow, i ), rowData, iRow, i
+                );
+            }
+        }
 
-		_fnCallbackFire( oSettings, 'aoRowCreatedCallback', null, [nTr, rowData, iRow] );
-	}
+        _fnCallbackFire( oSettings, 'aoRowCreatedCallback', null, [nTr, rowData, iRow] );
+    }
 
-	// Remove once webkit bug 131819 and Chromium bug 365619 have been resolved
-	// and deployed
-	row.nTr.setAttribute( 'role', 'row' );
+    // Remove once webkit bug 131819 and Chromium bug 365619 have been resolved
+    // and deployed
+    row.nTr.setAttribute( 'role', 'row' );
 }
 
 
@@ -94,36 +94,36 @@ function _fnCreateTr ( oSettings, iRow, nTrIn, anTds )
  */
 function _fnRowAttributes( settings, row )
 {
-	var tr = row.nTr;
-	var data = row._aData;
+    var tr = row.nTr;
+    var data = row._aData;
 
-	if ( tr ) {
-		var id = settings.rowIdFn( data );
+    if ( tr ) {
+        var id = settings.rowIdFn( data );
 
-		if ( id ) {
-			tr.id = id;
-		}
+        if ( id ) {
+            tr.id = id;
+        }
 
-		if ( data.DT_RowClass ) {
-			// Remove any classes added by DT_RowClass before
-			var a = data.DT_RowClass.split(' ');
-			row.__rowc = row.__rowc ?
-				_unique( row.__rowc.concat( a ) ) :
-				a;
+        if ( data.DT_RowClass ) {
+            // Remove any classes added by DT_RowClass before
+            var a = data.DT_RowClass.split(' ');
+            row.__rowc = row.__rowc ?
+                _unique( row.__rowc.concat( a ) ) :
+                a;
 
-			$(tr)
-				.removeClass( row.__rowc.join(' ') )
-				.addClass( data.DT_RowClass );
-		}
+            $(tr)
+                .removeClass( row.__rowc.join(' ') )
+                .addClass( data.DT_RowClass );
+        }
 
-		if ( data.DT_RowAttr ) {
-			$(tr).attr( data.DT_RowAttr );
-		}
+        if ( data.DT_RowAttr ) {
+            $(tr).attr( data.DT_RowAttr );
+        }
 
-		if ( data.DT_RowData ) {
-			$(tr).data( data.DT_RowData );
-		}
-	}
+        if ( data.DT_RowData ) {
+            $(tr).data( data.DT_RowData );
+        }
+    }
 }
 
 
@@ -134,74 +134,74 @@ function _fnRowAttributes( settings, row )
  */
 function _fnBuildHead( oSettings )
 {
-	var i, ien, cell, row, column;
-	var thead = oSettings.nTHead;
-	var tfoot = oSettings.nTFoot;
-	var createHeader = $('th, td', thead).length === 0;
-	var classes = oSettings.oClasses;
-	var columns = oSettings.aoColumns;
+    var i, ien, cell, row, column;
+    var thead = oSettings.nTHead;
+    var tfoot = oSettings.nTFoot;
+    var createHeader = $('th, td', thead).length === 0;
+    var classes = oSettings.oClasses;
+    var columns = oSettings.aoColumns;
 
-	if ( createHeader ) {
-		row = $('<tr/>').appendTo( thead );
-	}
+    if ( createHeader ) {
+        row = $('<tr/>').appendTo( thead );
+    }
 
-	for ( i=0, ien=columns.length ; i<ien ; i++ ) {
-		column = columns[i];
-		cell = $( column.nTh ).addClass( column.sClass );
+    for ( i=0, ien=columns.length ; i<ien ; i++ ) {
+        column = columns[i];
+        cell = $( column.nTh ).addClass( column.sClass );
 
-		if ( createHeader ) {
-			cell.appendTo( row );
-		}
+        if ( createHeader ) {
+            cell.appendTo( row );
+        }
 
-		// 1.11 move into sorting
-		if ( oSettings.oFeatures.bSort ) {
-			cell.addClass( column.sSortingClass );
+        // 1.11 move into sorting
+        if ( oSettings.oFeatures.bSort ) {
+            cell.addClass( column.sSortingClass );
 
-			if ( column.bSortable !== false ) {
-				cell
-					.attr( 'tabindex', oSettings.iTabIndex )
-					.attr( 'aria-controls', oSettings.sTableId );
+            if ( column.bSortable !== false ) {
+                cell
+                    .attr( 'tabindex', oSettings.iTabIndex )
+                    .attr( 'aria-controls', oSettings.sTableId );
 
-				_fnSortAttachListener( oSettings, column.nTh, i );
-			}
-		}
+                _fnSortAttachListener( oSettings, column.nTh, i );
+            }
+        }
 
-		if ( column.sTitle != cell[0].innerHTML ) {
-			cell.html( column.sTitle );
-		}
+        if ( column.sTitle != cell[0].innerHTML ) {
+            cell.html( column.sTitle );
+        }
 
-		_fnRenderer( oSettings, 'header' )(
-			oSettings, cell, column, classes
-		);
-	}
+        _fnRenderer( oSettings, 'header' )(
+            oSettings, cell, column, classes
+        );
+    }
 
-	if ( createHeader ) {
-		_fnDetectHeader( oSettings.aoHeader, thead );
-	}
-	
+    if ( createHeader ) {
+        _fnDetectHeader( oSettings.aoHeader, thead );
+    }
+
 	/* ARIA role for the rows */
- 	$(thead).find('>tr').attr('role', 'row');
+    $(thead).find('>tr').attr('role', 'row');
 
 	/* Deal with the footer - add classes if required */
-	$(thead).find('>tr>th, >tr>td').addClass( classes.sHeaderTH );
-	$(tfoot).find('>tr>th, >tr>td').addClass( classes.sFooterTH );
+    $(thead).find('>tr>th, >tr>td').addClass( classes.sHeaderTH );
+    $(tfoot).find('>tr>th, >tr>td').addClass( classes.sFooterTH );
 
-	// Cache the footer cells. Note that we only take the cells from the first
-	// row in the footer. If there is more than one row the user wants to
-	// interact with, they need to use the table().foot() method. Note also this
-	// allows cells to be used for multiple columns using colspan
-	if ( tfoot !== null ) {
-		var cells = oSettings.aoFooter[0];
+    // Cache the footer cells. Note that we only take the cells from the first
+    // row in the footer. If there is more than one row the user wants to
+    // interact with, they need to use the table().foot() method. Note also this
+    // allows cells to be used for multiple columns using colspan
+    if ( tfoot !== null ) {
+        var cells = oSettings.aoFooter[0];
 
-		for ( i=0, ien=cells.length ; i<ien ; i++ ) {
-			column = columns[i];
-			column.nTf = cells[i].cell;
+        for ( i=0, ien=cells.length ; i<ien ; i++ ) {
+            column = columns[i];
+            column.nTf = cells[i].cell;
 
-			if ( column.sClass ) {
-				$(column.nTf).addClass( column.sClass );
-			}
-		}
-	}
+            if ( column.sClass ) {
+                $(column.nTf).addClass( column.sClass );
+            }
+        }
+    }
 }
 
 
@@ -220,94 +220,94 @@ function _fnBuildHead( oSettings )
  */
 function _fnDrawHead( oSettings, aoSource, bIncludeHidden )
 {
-	var i, iLen, j, jLen, k, kLen, n, nLocalTr;
-	var aoLocal = [];
-	var aApplied = [];
-	var iColumns = oSettings.aoColumns.length;
-	var iRowspan, iColspan;
+    var i, iLen, j, jLen, k, kLen, n, nLocalTr;
+    var aoLocal = [];
+    var aApplied = [];
+    var iColumns = oSettings.aoColumns.length;
+    var iRowspan, iColspan;
 
-	if ( ! aoSource )
-	{
-		return;
-	}
+    if ( ! aoSource )
+    {
+        return;
+    }
 
-	if (  bIncludeHidden === undefined )
-	{
-		bIncludeHidden = false;
-	}
+    if (  bIncludeHidden === undefined )
+    {
+        bIncludeHidden = false;
+    }
 
 	/* Make a copy of the master layout array, but without the visible columns in it */
-	for ( i=0, iLen=aoSource.length ; i<iLen ; i++ )
-	{
-		aoLocal[i] = aoSource[i].slice();
-		aoLocal[i].nTr = aoSource[i].nTr;
+    for ( i=0, iLen=aoSource.length ; i<iLen ; i++ )
+    {
+        aoLocal[i] = aoSource[i].slice();
+        aoLocal[i].nTr = aoSource[i].nTr;
 
 		/* Remove any columns which are currently hidden */
-		for ( j=iColumns-1 ; j>=0 ; j-- )
-		{
-			if ( !oSettings.aoColumns[j].bVisible && !bIncludeHidden )
-			{
-				aoLocal[i].splice( j, 1 );
-			}
-		}
+        for ( j=iColumns-1 ; j>=0 ; j-- )
+        {
+            if ( !oSettings.aoColumns[j].bVisible && !bIncludeHidden )
+            {
+                aoLocal[i].splice( j, 1 );
+            }
+        }
 
 		/* Prep the applied array - it needs an element for each row */
-		aApplied.push( [] );
-	}
+        aApplied.push( [] );
+    }
 
-	for ( i=0, iLen=aoLocal.length ; i<iLen ; i++ )
-	{
-		nLocalTr = aoLocal[i].nTr;
+    for ( i=0, iLen=aoLocal.length ; i<iLen ; i++ )
+    {
+        nLocalTr = aoLocal[i].nTr;
 
 		/* All cells are going to be replaced, so empty out the row */
-		if ( nLocalTr )
-		{
-			while( (n = nLocalTr.firstChild) )
-			{
-				nLocalTr.removeChild( n );
-			}
-		}
+        if ( nLocalTr )
+        {
+            while( (n = nLocalTr.firstChild) )
+            {
+                nLocalTr.removeChild( n );
+            }
+        }
 
-		for ( j=0, jLen=aoLocal[i].length ; j<jLen ; j++ )
-		{
-			iRowspan = 1;
-			iColspan = 1;
+        for ( j=0, jLen=aoLocal[i].length ; j<jLen ; j++ )
+        {
+            iRowspan = 1;
+            iColspan = 1;
 
 			/* Check to see if there is already a cell (row/colspan) covering our target
 			 * insert point. If there is, then there is nothing to do.
 			 */
-			if ( aApplied[i][j] === undefined )
-			{
-				nLocalTr.appendChild( aoLocal[i][j].cell );
-				aApplied[i][j] = 1;
+            if ( aApplied[i][j] === undefined )
+            {
+                nLocalTr.appendChild( aoLocal[i][j].cell );
+                aApplied[i][j] = 1;
 
 				/* Expand the cell to cover as many rows as needed */
-				while ( aoLocal[i+iRowspan] !== undefined &&
-				        aoLocal[i][j].cell == aoLocal[i+iRowspan][j].cell )
-				{
-					aApplied[i+iRowspan][j] = 1;
-					iRowspan++;
-				}
+                while ( aoLocal[i+iRowspan] !== undefined &&
+                aoLocal[i][j].cell == aoLocal[i+iRowspan][j].cell )
+                {
+                    aApplied[i+iRowspan][j] = 1;
+                    iRowspan++;
+                }
 
 				/* Expand the cell to cover as many columns as needed */
-				while ( aoLocal[i][j+iColspan] !== undefined &&
-				        aoLocal[i][j].cell == aoLocal[i][j+iColspan].cell )
-				{
+                while ( aoLocal[i][j+iColspan] !== undefined &&
+                aoLocal[i][j].cell == aoLocal[i][j+iColspan].cell )
+                {
 					/* Must update the applied array over the rows for the columns */
-					for ( k=0 ; k<iRowspan ; k++ )
-					{
-						aApplied[i+k][j+iColspan] = 1;
-					}
-					iColspan++;
-				}
+                    for ( k=0 ; k<iRowspan ; k++ )
+                    {
+                        aApplied[i+k][j+iColspan] = 1;
+                    }
+                    iColspan++;
+                }
 
 				/* Do the actual expansion in the DOM */
-				$(aoLocal[i][j].cell)
-					.attr('rowspan', iRowspan)
-					.attr('colspan', iColspan);
-			}
-		}
-	}
+                $(aoLocal[i][j].cell)
+                    .attr('rowspan', iRowspan)
+                    .attr('colspan', iColspan);
+            }
+        }
+    }
 }
 
 
@@ -319,134 +319,134 @@ function _fnDrawHead( oSettings, aoSource, bIncludeHidden )
 function _fnDraw( oSettings )
 {
 	/* Provide a pre-callback function which can be used to cancel the draw is false is returned */
-	var aPreDraw = _fnCallbackFire( oSettings, 'aoPreDrawCallback', 'preDraw', [oSettings] );
-	if ( $.inArray( false, aPreDraw ) !== -1 )
-	{
-		_fnProcessingDisplay( oSettings, false );
-		return;
-	}
+    var aPreDraw = _fnCallbackFire( oSettings, 'aoPreDrawCallback', 'preDraw', [oSettings] );
+    if ( $.inArray( false, aPreDraw ) !== -1 )
+    {
+        _fnProcessingDisplay( oSettings, false );
+        return;
+    }
 
-	var i, iLen, n;
-	var anRows = [];
-	var iRowCount = 0;
-	var asStripeClasses = oSettings.asStripeClasses;
-	var iStripes = asStripeClasses.length;
-	var iOpenRows = oSettings.aoOpenRows.length;
-	var oLang = oSettings.oLanguage;
-	var iInitDisplayStart = oSettings.iInitDisplayStart;
-	var bServerSide = _fnDataSource( oSettings ) == 'ssp';
-	var aiDisplay = oSettings.aiDisplay;
+    var i, iLen, n;
+    var anRows = [];
+    var iRowCount = 0;
+    var asStripeClasses = oSettings.asStripeClasses;
+    var iStripes = asStripeClasses.length;
+    var iOpenRows = oSettings.aoOpenRows.length;
+    var oLang = oSettings.oLanguage;
+    var iInitDisplayStart = oSettings.iInitDisplayStart;
+    var bServerSide = _fnDataSource( oSettings ) == 'ssp';
+    var aiDisplay = oSettings.aiDisplay;
 
-	oSettings.bDrawing = true;
+    oSettings.bDrawing = true;
 
 	/* Check and see if we have an initial draw position from state saving */
-	if ( iInitDisplayStart !== undefined && iInitDisplayStart !== -1 )
-	{
-		oSettings._iDisplayStart = bServerSide ?
-			iInitDisplayStart :
-			iInitDisplayStart >= oSettings.fnRecordsDisplay() ?
-				0 :
-				iInitDisplayStart;
+    if ( iInitDisplayStart !== undefined && iInitDisplayStart !== -1 )
+    {
+        oSettings._iDisplayStart = bServerSide ?
+            iInitDisplayStart :
+            iInitDisplayStart >= oSettings.fnRecordsDisplay() ?
+                0 :
+                iInitDisplayStart;
 
-		oSettings.iInitDisplayStart = -1;
-	}
+        oSettings.iInitDisplayStart = -1;
+    }
 
-	var iDisplayStart = oSettings._iDisplayStart;
-	var iDisplayEnd = oSettings.fnDisplayEnd();
+    var iDisplayStart = oSettings._iDisplayStart;
+    var iDisplayEnd = oSettings.fnDisplayEnd();
 
 	/* Server-side processing draw intercept */
-	if ( oSettings.bDeferLoading )
-	{
-		oSettings.bDeferLoading = false;
-		oSettings.iDraw++;
-		_fnProcessingDisplay( oSettings, false );
-	}
-	else if ( !bServerSide )
-	{
-		oSettings.iDraw++;
-	}
-	else if ( !oSettings.bDestroying && !_fnAjaxUpdate( oSettings ) )
-	{
-		return;
-	}
+    if ( oSettings.bDeferLoading )
+    {
+        oSettings.bDeferLoading = false;
+        oSettings.iDraw++;
+        _fnProcessingDisplay( oSettings, false );
+    }
+    else if ( !bServerSide )
+    {
+        oSettings.iDraw++;
+    }
+    else if ( !oSettings.bDestroying && !_fnAjaxUpdate( oSettings ) )
+    {
+        return;
+    }
 
-	if ( aiDisplay.length !== 0 )
-	{
-		var iStart = bServerSide ? 0 : iDisplayStart;
-		var iEnd = bServerSide ? oSettings.aoData.length : iDisplayEnd;
+    if ( aiDisplay.length !== 0 )
+    {
+        var iStart = bServerSide ? 0 : iDisplayStart;
+        var iEnd = bServerSide ? oSettings.aoData.length : iDisplayEnd;
 
-		for ( var j=iStart ; j<iEnd ; j++ )
-		{
-			var iDataIndex = aiDisplay[j];
-			var aoData = oSettings.aoData[ iDataIndex ];
-			if ( aoData.nTr === null )
-			{
-				_fnCreateTr( oSettings, iDataIndex );
-			}
+        for ( var j=iStart ; j<iEnd ; j++ )
+        {
+            var iDataIndex = aiDisplay[j];
+            var aoData = oSettings.aoData[ iDataIndex ];
+            if ( aoData.nTr === null )
+            {
+                _fnCreateTr( oSettings, iDataIndex );
+            }
 
-			var nRow = aoData.nTr;
+            var nRow = aoData.nTr;
 
 			/* Remove the old striping classes and then add the new one */
-			if ( iStripes !== 0 )
-			{
-				var sStripe = asStripeClasses[ iRowCount % iStripes ];
-				if ( aoData._sRowStripe != sStripe )
-				{
-					$(nRow).removeClass( aoData._sRowStripe ).addClass( sStripe );
-					aoData._sRowStripe = sStripe;
-				}
-			}
+            if ( iStripes !== 0 )
+            {
+                var sStripe = asStripeClasses[ iRowCount % iStripes ];
+                if ( aoData._sRowStripe != sStripe )
+                {
+                    $(nRow).removeClass( aoData._sRowStripe ).addClass( sStripe );
+                    aoData._sRowStripe = sStripe;
+                }
+            }
 
-			// Row callback functions - might want to manipulate the row
-			// iRowCount and j are not currently documented. Are they at all
-			// useful?
-			_fnCallbackFire( oSettings, 'aoRowCallback', null,
-				[nRow, aoData._aData, iRowCount, j] );
+            // Row callback functions - might want to manipulate the row
+            // iRowCount and j are not currently documented. Are they at all
+            // useful?
+            _fnCallbackFire( oSettings, 'aoRowCallback', null,
+                [nRow, aoData._aData, iRowCount, j] );
 
-			anRows.push( nRow );
-			iRowCount++;
-		}
-	}
-	else
-	{
+            anRows.push( nRow );
+            iRowCount++;
+        }
+    }
+    else
+    {
 		/* Table is empty - create a row with an empty message in it */
-		var sZero = oLang.sZeroRecords;
-		if ( oSettings.iDraw == 1 &&  _fnDataSource( oSettings ) == 'ajax' )
-		{
-			sZero = oLang.sLoadingRecords;
-		}
-		else if ( oLang.sEmptyTable && oSettings.fnRecordsTotal() === 0 )
-		{
-			sZero = oLang.sEmptyTable;
-		}
+        var sZero = oLang.sZeroRecords;
+        if ( oSettings.iDraw == 1 &&  _fnDataSource( oSettings ) == 'ajax' )
+        {
+            sZero = oLang.sLoadingRecords;
+        }
+        else if ( oLang.sEmptyTable && oSettings.fnRecordsTotal() === 0 )
+        {
+            sZero = oLang.sEmptyTable;
+        }
 
-		anRows[ 0 ] = $( '<tr/>', { 'class': iStripes ? asStripeClasses[0] : '' } )
-			.append( $('<td />', {
-				'valign':  'top',
-				'colSpan': _fnVisbleColumns( oSettings ),
-				'class':   oSettings.oClasses.sRowEmpty
-			} ).html( sZero ) )[0];
-	}
+        anRows[ 0 ] = $( '<tr/>', { 'class': iStripes ? asStripeClasses[0] : '' } )
+            .append( $('<td />', {
+                'valign':  'top',
+                'colSpan': _fnVisbleColumns( oSettings ),
+                'class':   oSettings.oClasses.sRowEmpty
+            } ).html( sZero ) )[0];
+    }
 
 	/* Header and footer callbacks */
-	_fnCallbackFire( oSettings, 'aoHeaderCallback', 'header', [ $(oSettings.nTHead).children('tr')[0],
-		_fnGetDataMaster( oSettings ), iDisplayStart, iDisplayEnd, aiDisplay ] );
+    _fnCallbackFire( oSettings, 'aoHeaderCallback', 'header', [ $(oSettings.nTHead).children('tr')[0],
+        _fnGetDataMaster( oSettings ), iDisplayStart, iDisplayEnd, aiDisplay ] );
 
-	_fnCallbackFire( oSettings, 'aoFooterCallback', 'footer', [ $(oSettings.nTFoot).children('tr')[0],
-		_fnGetDataMaster( oSettings ), iDisplayStart, iDisplayEnd, aiDisplay ] );
+    _fnCallbackFire( oSettings, 'aoFooterCallback', 'footer', [ $(oSettings.nTFoot).children('tr')[0],
+        _fnGetDataMaster( oSettings ), iDisplayStart, iDisplayEnd, aiDisplay ] );
 
-	var body = $(oSettings.nTBody);
+    var body = $(oSettings.nTBody);
 
-	body.children().detach();
-	body.append( $(anRows) );
+    body.children().detach();
+    body.append( $(anRows) );
 
 	/* Call all required callback functions for the end of a draw */
-	_fnCallbackFire( oSettings, 'aoDrawCallback', 'draw', [oSettings] );
+    _fnCallbackFire( oSettings, 'aoDrawCallback', 'draw', [oSettings] );
 
 	/* Draw is complete, sorting and filtering must be as well */
-	oSettings.bSorted = false;
-	oSettings.bFiltered = false;
-	oSettings.bDrawing = false;
+    oSettings.bSorted = false;
+    oSettings.bFiltered = false;
+    oSettings.bDrawing = false;
 }
 
 
@@ -459,34 +459,34 @@ function _fnDraw( oSettings )
  */
 function _fnReDraw( settings, holdPosition )
 {
-	var
-		features = settings.oFeatures,
-		sort     = features.bSort,
-		filter   = features.bFilter;
+    var
+        features = settings.oFeatures,
+        sort     = features.bSort,
+        filter   = features.bFilter;
 
-	if ( sort ) {
-		_fnSort( settings );
-	}
+    if ( sort ) {
+        _fnSort( settings );
+    }
 
-	if ( filter ) {
-		_fnFilterComplete( settings, settings.oPreviousSearch );
-	}
-	else {
-		// No filtering, so we want to just use the display master
-		settings.aiDisplay = settings.aiDisplayMaster.slice();
-	}
+    if ( filter ) {
+        _fnFilterComplete( settings, settings.oPreviousSearch );
+    }
+    else {
+        // No filtering, so we want to just use the display master
+        settings.aiDisplay = settings.aiDisplayMaster.slice();
+    }
 
-	if ( holdPosition !== true ) {
-		settings._iDisplayStart = 0;
-	}
+    if ( holdPosition !== true ) {
+        settings._iDisplayStart = 0;
+    }
 
-	// Let any modules know about the draw hold position state (used by
-	// scrolling internally)
-	settings._drawHold = holdPosition;
+    // Let any modules know about the draw hold position state (used by
+    // scrolling internally)
+    settings._drawHold = holdPosition;
 
-	_fnDraw( settings );
+    _fnDraw( settings );
 
-	settings._drawHold = false;
+    settings._drawHold = false;
 }
 
 
@@ -497,148 +497,153 @@ function _fnReDraw( settings, holdPosition )
  */
 function _fnAddOptionsHtml ( oSettings )
 {
-	var classes = oSettings.oClasses;
-	var table = $(oSettings.nTable);
-	var holding = $('<div/>').insertBefore( table ); // Holding element for speed
-	var features = oSettings.oFeatures;
+    var classes = oSettings.oClasses;
+    var table = $(oSettings.nTable);
+    var holding = $('<div/>').insertBefore( table ); // Holding element for speed
+    var features = oSettings.oFeatures;
 
-	// All DataTables are wrapped in a div
-	var insert = $('<div/>', {
-		id:      oSettings.sTableId+'_wrapper',
-		'class': classes.sWrapper + (oSettings.nTFoot ? '' : ' '+classes.sNoFooter)
-	} );
+    // All DataTables are wrapped in a div
+    var insert = $('<div/>', {
+        id:      oSettings.sTableId+'_wrapper',
+        'class': classes.sWrapper + (oSettings.nTFoot ? '' : ' '+classes.sNoFooter)
+    } );
 
-	oSettings.nHolding = holding[0];
-	oSettings.nTableWrapper = insert[0];
-	oSettings.nTableReinsertBefore = oSettings.nTable.nextSibling;
+    oSettings.nHolding = holding[0];
+    oSettings.nTableWrapper = insert[0];
+    oSettings.nTableReinsertBefore = oSettings.nTable.nextSibling;
 
 	/* Loop over the user set positioning and place the elements as needed */
-	var aDom = oSettings.sDom.split('');
-	var featureNode, cOption, nNewNode, cNext, sAttr, j;
-	for ( var i=0 ; i<aDom.length ; i++ )
-	{
-		featureNode = null;
-		cOption = aDom[i];
+    var aDom = oSettings.sDom.split('');
+    var featureNode, cOption, nNewNode, cNext, sAttr, j;
+    for ( var i=0 ; i<aDom.length ; i++ )
+    {
+        featureNode = null;
+        cOption = aDom[i];
 
-		if ( cOption == '<' )
-		{
+        if ( cOption == '<' )
+        {
 			/* New container div */
-			nNewNode = $('<div/>')[0];
+            nNewNode = $('<div/>')[0];
 
 			/* Check to see if we should append an id and/or a class name to the container */
-			cNext = aDom[i+1];
-			if ( cNext == "'" || cNext == '"' )
-			{
-				sAttr = "";
-				j = 2;
-				while ( aDom[i+j] != cNext )
-				{
-					sAttr += aDom[i+j];
-					j++;
-				}
+            cNext = aDom[i+1];
+            if ( cNext == "'" || cNext == '"' )
+            {
+                sAttr = "";
+                j = 2;
+                while ( aDom[i+j] != cNext )
+                {
+                    sAttr += aDom[i+j];
+                    j++;
+                }
 
 				/* Replace jQuery UI constants @todo depreciated */
-				if ( sAttr == "H" )
-				{
-					sAttr = classes.sJUIHeader;
-				}
-				else if ( sAttr == "F" )
-				{
-					sAttr = classes.sJUIFooter;
-				}
+                if ( sAttr == "H" )
+                {
+                    sAttr = classes.sJUIHeader;
+                }
+                else if ( sAttr == "F" )
+                {
+                    sAttr = classes.sJUIFooter;
+                }
 
 				/* The attribute can be in the format of "#id.class", "#id" or "class" This logic
 				 * breaks the string into parts and applies them as needed
 				 */
-				if ( sAttr.indexOf('.') != -1 )
-				{
-					var aSplit = sAttr.split('.');
-					nNewNode.id = aSplit[0].substr(1, aSplit[0].length-1);
-					nNewNode.className = aSplit[1];
-				}
-				else if ( sAttr.charAt(0) == "#" )
-				{
-					nNewNode.id = sAttr.substr(1, sAttr.length-1);
-				}
-				else
-				{
-					nNewNode.className = sAttr;
-				}
+                if ( sAttr.indexOf('.') != -1 )
+                {
+                    var aSplit = sAttr.split('.');
+                    nNewNode.id = aSplit[0].substr(1, aSplit[0].length-1);
+                    nNewNode.className = aSplit[1];
+                }
+                else if ( sAttr.charAt(0) == "#" )
+                {
+                    nNewNode.id = sAttr.substr(1, sAttr.length-1);
+                }
+                else
+                {
+                    nNewNode.className = sAttr;
+                }
 
-				i += j; /* Move along the position array */
-			}
+                i += j; /* Move along the position array */
+            }
 
-			insert.append( nNewNode );
-			insert = $(nNewNode);
-		}
-		else if ( cOption == '>' )
-		{
+            insert.append( nNewNode );
+            insert = $(nNewNode);
+        }
+        else if ( cOption == '>' )
+        {
 			/* End container div */
-			insert = insert.parent();
-		}
-		// @todo Move options into their own plugins?
-		else if ( cOption == 'l' && features.bPaginate && features.bLengthChange )
-		{
+            insert = insert.parent();
+        }
+        // @todo Move options into their own plugins?
+        else if ( cOption == 'l' && features.bPaginate && features.bLengthChange )
+        {
 			/* Length */
-			featureNode = _fnFeatureHtmlLength( oSettings );
-		}
-		else if ( cOption == 'f' && features.bFilter )
-		{
+            featureNode = _fnFeatureHtmlLength( oSettings );
+        }
+        else if ( cOption == 'e' && features.bExclude )
+        {
+			/* Exclude */
+            featureNode = _fnFeatureHtmlExclude( oSettings );
+        }
+        else if ( cOption == 'f' && features.bFilter )
+        {
 			/* Filter */
-			featureNode = _fnFeatureHtmlFilter( oSettings );
-		}
-		else if ( cOption == 'r' && features.bProcessing )
-		{
+            featureNode = _fnFeatureHtmlFilter( oSettings );
+        }
+        else if ( cOption == 'r' && features.bProcessing )
+        {
 			/* pRocessing */
-			featureNode = _fnFeatureHtmlProcessing( oSettings );
-		}
-		else if ( cOption == 't' )
-		{
+            featureNode = _fnFeatureHtmlProcessing( oSettings );
+        }
+        else if ( cOption == 't' )
+        {
 			/* Table */
-			featureNode = _fnFeatureHtmlTable( oSettings );
-		}
-		else if ( cOption ==  'i' && features.bInfo )
-		{
+            featureNode = _fnFeatureHtmlTable( oSettings );
+        }
+        else if ( cOption ==  'i' && features.bInfo )
+        {
 			/* Info */
-			featureNode = _fnFeatureHtmlInfo( oSettings );
-		}
-		else if ( cOption == 'p' && features.bPaginate )
-		{
+            featureNode = _fnFeatureHtmlInfo( oSettings );
+        }
+        else if ( cOption == 'p' && features.bPaginate )
+        {
 			/* Pagination */
-			featureNode = _fnFeatureHtmlPaginate( oSettings );
-		}
-		else if ( DataTable.ext.feature.length !== 0 )
-		{
+            featureNode = _fnFeatureHtmlPaginate( oSettings );
+        }
+        else if ( DataTable.ext.feature.length !== 0 )
+        {
 			/* Plug-in features */
-			var aoFeatures = DataTable.ext.feature;
-			for ( var k=0, kLen=aoFeatures.length ; k<kLen ; k++ )
-			{
-				if ( cOption == aoFeatures[k].cFeature )
-				{
-					featureNode = aoFeatures[k].fnInit( oSettings );
-					break;
-				}
-			}
-		}
+            var aoFeatures = DataTable.ext.feature;
+            for ( var k=0, kLen=aoFeatures.length ; k<kLen ; k++ )
+            {
+                if ( cOption == aoFeatures[k].cFeature )
+                {
+                    featureNode = aoFeatures[k].fnInit( oSettings );
+                    break;
+                }
+            }
+        }
 
 		/* Add to the 2D features array */
-		if ( featureNode )
-		{
-			var aanFeatures = oSettings.aanFeatures;
+        if ( featureNode )
+        {
+            var aanFeatures = oSettings.aanFeatures;
 
-			if ( ! aanFeatures[cOption] )
-			{
-				aanFeatures[cOption] = [];
-			}
+            if ( ! aanFeatures[cOption] )
+            {
+                aanFeatures[cOption] = [];
+            }
 
-			aanFeatures[cOption].push( featureNode );
-			insert.append( featureNode );
-		}
-	}
+            aanFeatures[cOption].push( featureNode );
+            insert.append( featureNode );
+        }
+    }
 
 	/* Built our DOM structure - replace the holding div with what we want */
-	holding.replaceWith( insert );
-	oSettings.nHolding = null;
+    holding.replaceWith( insert );
+    oSettings.nHolding = null;
 }
 
 
@@ -653,68 +658,68 @@ function _fnAddOptionsHtml ( oSettings )
  */
 function _fnDetectHeader ( aLayout, nThead )
 {
-	var nTrs = $(nThead).children('tr');
-	var nTr, nCell;
-	var i, k, l, iLen, jLen, iColShifted, iColumn, iColspan, iRowspan;
-	var bUnique;
-	var fnShiftCol = function ( a, i, j ) {
-		var k = a[i];
-                while ( k[j] ) {
-			j++;
-		}
-		return j;
-	};
+    var nTrs = $(nThead).children('tr');
+    var nTr, nCell;
+    var i, k, l, iLen, jLen, iColShifted, iColumn, iColspan, iRowspan;
+    var bUnique;
+    var fnShiftCol = function ( a, i, j ) {
+        var k = a[i];
+        while ( k[j] ) {
+            j++;
+        }
+        return j;
+    };
 
-	aLayout.splice( 0, aLayout.length );
+    aLayout.splice( 0, aLayout.length );
 
 	/* We know how many rows there are in the layout - so prep it */
-	for ( i=0, iLen=nTrs.length ; i<iLen ; i++ )
-	{
-		aLayout.push( [] );
-	}
+    for ( i=0, iLen=nTrs.length ; i<iLen ; i++ )
+    {
+        aLayout.push( [] );
+    }
 
 	/* Calculate a layout array */
-	for ( i=0, iLen=nTrs.length ; i<iLen ; i++ )
-	{
-		nTr = nTrs[i];
-		iColumn = 0;
+    for ( i=0, iLen=nTrs.length ; i<iLen ; i++ )
+    {
+        nTr = nTrs[i];
+        iColumn = 0;
 
 		/* For every cell in the row... */
-		nCell = nTr.firstChild;
-		while ( nCell ) {
-			if ( nCell.nodeName.toUpperCase() == "TD" ||
-			     nCell.nodeName.toUpperCase() == "TH" )
-			{
+        nCell = nTr.firstChild;
+        while ( nCell ) {
+            if ( nCell.nodeName.toUpperCase() == "TD" ||
+                nCell.nodeName.toUpperCase() == "TH" )
+            {
 				/* Get the col and rowspan attributes from the DOM and sanitise them */
-				iColspan = nCell.getAttribute('colspan') * 1;
-				iRowspan = nCell.getAttribute('rowspan') * 1;
-				iColspan = (!iColspan || iColspan===0 || iColspan===1) ? 1 : iColspan;
-				iRowspan = (!iRowspan || iRowspan===0 || iRowspan===1) ? 1 : iRowspan;
+                iColspan = nCell.getAttribute('colspan') * 1;
+                iRowspan = nCell.getAttribute('rowspan') * 1;
+                iColspan = (!iColspan || iColspan===0 || iColspan===1) ? 1 : iColspan;
+                iRowspan = (!iRowspan || iRowspan===0 || iRowspan===1) ? 1 : iRowspan;
 
 				/* There might be colspan cells already in this row, so shift our target
 				 * accordingly
 				 */
-				iColShifted = fnShiftCol( aLayout, i, iColumn );
+                iColShifted = fnShiftCol( aLayout, i, iColumn );
 
 				/* Cache calculation for unique columns */
-				bUnique = iColspan === 1 ? true : false;
+                bUnique = iColspan === 1 ? true : false;
 
 				/* If there is col / rowspan, copy the information into the layout grid */
-				for ( l=0 ; l<iColspan ; l++ )
-				{
-					for ( k=0 ; k<iRowspan ; k++ )
-					{
-						aLayout[i+k][iColShifted+l] = {
-							"cell": nCell,
-							"unique": bUnique
-						};
-						aLayout[i+k].nTr = nTr;
-					}
-				}
-			}
-			nCell = nCell.nextSibling;
-		}
-	}
+                for ( l=0 ; l<iColspan ; l++ )
+                {
+                    for ( k=0 ; k<iRowspan ; k++ )
+                    {
+                        aLayout[i+k][iColShifted+l] = {
+                            "cell": nCell,
+                            "unique": bUnique
+                        };
+                        aLayout[i+k].nTr = nTr;
+                    }
+                }
+            }
+            nCell = nCell.nextSibling;
+        }
+    }
 }
 
 
@@ -728,29 +733,29 @@ function _fnDetectHeader ( aLayout, nThead )
  */
 function _fnGetUniqueThs ( oSettings, nHeader, aLayout )
 {
-	var aReturn = [];
-	if ( !aLayout )
-	{
-		aLayout = oSettings.aoHeader;
-		if ( nHeader )
-		{
-			aLayout = [];
-			_fnDetectHeader( aLayout, nHeader );
-		}
-	}
+    var aReturn = [];
+    if ( !aLayout )
+    {
+        aLayout = oSettings.aoHeader;
+        if ( nHeader )
+        {
+            aLayout = [];
+            _fnDetectHeader( aLayout, nHeader );
+        }
+    }
 
-	for ( var i=0, iLen=aLayout.length ; i<iLen ; i++ )
-	{
-		for ( var j=0, jLen=aLayout[i].length ; j<jLen ; j++ )
-		{
-			if ( aLayout[i][j].unique &&
-				 (!aReturn[j] || !oSettings.bSortCellsTop) )
-			{
-				aReturn[j] = aLayout[i][j].cell;
-			}
-		}
-	}
+    for ( var i=0, iLen=aLayout.length ; i<iLen ; i++ )
+    {
+        for ( var j=0, jLen=aLayout[i].length ; j<jLen ; j++ )
+        {
+            if ( aLayout[i][j].unique &&
+                (!aReturn[j] || !oSettings.bSortCellsTop) )
+            {
+                aReturn[j] = aLayout[i][j].cell;
+            }
+        }
+    }
 
-	return aReturn;
+    return aReturn;
 }
 

--- a/js/core/core.draw.js
+++ b/js/core/core.draw.js
@@ -10,78 +10,78 @@
  */
 function _fnCreateTr ( oSettings, iRow, nTrIn, anTds )
 {
-    var
-        row = oSettings.aoData[iRow],
-        rowData = row._aData,
-        cells = [],
-        nTr, nTd, oCol,
-        i, iLen;
+	var
+		row = oSettings.aoData[iRow],
+		rowData = row._aData,
+		cells = [],
+		nTr, nTd, oCol,
+		i, iLen;
 
-    if ( row.nTr === null )
-    {
-        nTr = nTrIn || document.createElement('tr');
+	if ( row.nTr === null )
+	{
+		nTr = nTrIn || document.createElement('tr');
 
-        row.nTr = nTr;
-        row.anCells = cells;
+		row.nTr = nTr;
+		row.anCells = cells;
 
 		/* Use a private property on the node to allow reserve mapping from the node
 		 * to the aoData array for fast look up
 		 */
-        nTr._DT_RowIndex = iRow;
+		nTr._DT_RowIndex = iRow;
 
 		/* Special parameters can be given by the data source to be used on the row */
-        _fnRowAttributes( oSettings, row );
+		_fnRowAttributes( oSettings, row );
 
 		/* Process each column */
-        for ( i=0, iLen=oSettings.aoColumns.length ; i<iLen ; i++ )
-        {
-            oCol = oSettings.aoColumns[i];
+		for ( i=0, iLen=oSettings.aoColumns.length ; i<iLen ; i++ )
+		{
+			oCol = oSettings.aoColumns[i];
 
-            nTd = nTrIn ? anTds[i] : document.createElement( oCol.sCellType );
-            nTd._DT_CellIndex = {
-                row: iRow,
-                column: i
-            };
+			nTd = nTrIn ? anTds[i] : document.createElement( oCol.sCellType );
+			nTd._DT_CellIndex = {
+				row: iRow,
+				column: i
+			};
 
-            cells.push( nTd );
+			cells.push( nTd );
 
-            // Need to create the HTML if new, or if a rendering function is defined
-            if ( (!nTrIn || oCol.mRender || oCol.mData !== i) &&
-                (!$.isPlainObject(oCol.mData) || oCol.mData._ !== i+'.display')
-            ) {
-                nTd.innerHTML = _fnGetCellData( oSettings, iRow, i, 'display' );
-            }
+			// Need to create the HTML if new, or if a rendering function is defined
+			if ( (!nTrIn || oCol.mRender || oCol.mData !== i) &&
+				 (!$.isPlainObject(oCol.mData) || oCol.mData._ !== i+'.display')
+			) {
+				nTd.innerHTML = _fnGetCellData( oSettings, iRow, i, 'display' );
+			}
 
 			/* Add user defined class */
-            if ( oCol.sClass )
-            {
-                nTd.className += ' '+oCol.sClass;
-            }
+			if ( oCol.sClass )
+			{
+				nTd.className += ' '+oCol.sClass;
+			}
 
-            // Visibility - add or remove as required
-            if ( oCol.bVisible && ! nTrIn )
-            {
-                nTr.appendChild( nTd );
-            }
-            else if ( ! oCol.bVisible && nTrIn )
-            {
-                nTd.parentNode.removeChild( nTd );
-            }
+			// Visibility - add or remove as required
+			if ( oCol.bVisible && ! nTrIn )
+			{
+				nTr.appendChild( nTd );
+			}
+			else if ( ! oCol.bVisible && nTrIn )
+			{
+				nTd.parentNode.removeChild( nTd );
+			}
 
-            if ( oCol.fnCreatedCell )
-            {
-                oCol.fnCreatedCell.call( oSettings.oInstance,
-                    nTd, _fnGetCellData( oSettings, iRow, i ), rowData, iRow, i
-                );
-            }
-        }
+			if ( oCol.fnCreatedCell )
+			{
+				oCol.fnCreatedCell.call( oSettings.oInstance,
+					nTd, _fnGetCellData( oSettings, iRow, i ), rowData, iRow, i
+				);
+			}
+		}
 
-        _fnCallbackFire( oSettings, 'aoRowCreatedCallback', null, [nTr, rowData, iRow] );
-    }
+		_fnCallbackFire( oSettings, 'aoRowCreatedCallback', null, [nTr, rowData, iRow] );
+	}
 
-    // Remove once webkit bug 131819 and Chromium bug 365619 have been resolved
-    // and deployed
-    row.nTr.setAttribute( 'role', 'row' );
+	// Remove once webkit bug 131819 and Chromium bug 365619 have been resolved
+	// and deployed
+	row.nTr.setAttribute( 'role', 'row' );
 }
 
 
@@ -94,36 +94,36 @@ function _fnCreateTr ( oSettings, iRow, nTrIn, anTds )
  */
 function _fnRowAttributes( settings, row )
 {
-    var tr = row.nTr;
-    var data = row._aData;
+	var tr = row.nTr;
+	var data = row._aData;
 
-    if ( tr ) {
-        var id = settings.rowIdFn( data );
+	if ( tr ) {
+		var id = settings.rowIdFn( data );
 
-        if ( id ) {
-            tr.id = id;
-        }
+		if ( id ) {
+			tr.id = id;
+		}
 
-        if ( data.DT_RowClass ) {
-            // Remove any classes added by DT_RowClass before
-            var a = data.DT_RowClass.split(' ');
-            row.__rowc = row.__rowc ?
-                _unique( row.__rowc.concat( a ) ) :
-                a;
+		if ( data.DT_RowClass ) {
+			// Remove any classes added by DT_RowClass before
+			var a = data.DT_RowClass.split(' ');
+			row.__rowc = row.__rowc ?
+				_unique( row.__rowc.concat( a ) ) :
+				a;
 
-            $(tr)
-                .removeClass( row.__rowc.join(' ') )
-                .addClass( data.DT_RowClass );
-        }
+			$(tr)
+				.removeClass( row.__rowc.join(' ') )
+				.addClass( data.DT_RowClass );
+		}
 
-        if ( data.DT_RowAttr ) {
-            $(tr).attr( data.DT_RowAttr );
-        }
+		if ( data.DT_RowAttr ) {
+			$(tr).attr( data.DT_RowAttr );
+		}
 
-        if ( data.DT_RowData ) {
-            $(tr).data( data.DT_RowData );
-        }
-    }
+		if ( data.DT_RowData ) {
+			$(tr).data( data.DT_RowData );
+		}
+	}
 }
 
 
@@ -134,74 +134,74 @@ function _fnRowAttributes( settings, row )
  */
 function _fnBuildHead( oSettings )
 {
-    var i, ien, cell, row, column;
-    var thead = oSettings.nTHead;
-    var tfoot = oSettings.nTFoot;
-    var createHeader = $('th, td', thead).length === 0;
-    var classes = oSettings.oClasses;
-    var columns = oSettings.aoColumns;
+	var i, ien, cell, row, column;
+	var thead = oSettings.nTHead;
+	var tfoot = oSettings.nTFoot;
+	var createHeader = $('th, td', thead).length === 0;
+	var classes = oSettings.oClasses;
+	var columns = oSettings.aoColumns;
 
-    if ( createHeader ) {
-        row = $('<tr/>').appendTo( thead );
-    }
+	if ( createHeader ) {
+		row = $('<tr/>').appendTo( thead );
+	}
 
-    for ( i=0, ien=columns.length ; i<ien ; i++ ) {
-        column = columns[i];
-        cell = $( column.nTh ).addClass( column.sClass );
+	for ( i=0, ien=columns.length ; i<ien ; i++ ) {
+		column = columns[i];
+		cell = $( column.nTh ).addClass( column.sClass );
 
-        if ( createHeader ) {
-            cell.appendTo( row );
-        }
+		if ( createHeader ) {
+			cell.appendTo( row );
+		}
 
-        // 1.11 move into sorting
-        if ( oSettings.oFeatures.bSort ) {
-            cell.addClass( column.sSortingClass );
+		// 1.11 move into sorting
+		if ( oSettings.oFeatures.bSort ) {
+			cell.addClass( column.sSortingClass );
 
-            if ( column.bSortable !== false ) {
-                cell
-                    .attr( 'tabindex', oSettings.iTabIndex )
-                    .attr( 'aria-controls', oSettings.sTableId );
+			if ( column.bSortable !== false ) {
+				cell
+					.attr( 'tabindex', oSettings.iTabIndex )
+					.attr( 'aria-controls', oSettings.sTableId );
 
-                _fnSortAttachListener( oSettings, column.nTh, i );
-            }
-        }
+				_fnSortAttachListener( oSettings, column.nTh, i );
+			}
+		}
 
-        if ( column.sTitle != cell[0].innerHTML ) {
-            cell.html( column.sTitle );
-        }
+		if ( column.sTitle != cell[0].innerHTML ) {
+			cell.html( column.sTitle );
+		}
 
-        _fnRenderer( oSettings, 'header' )(
-            oSettings, cell, column, classes
-        );
-    }
+		_fnRenderer( oSettings, 'header' )(
+			oSettings, cell, column, classes
+		);
+	}
 
-    if ( createHeader ) {
-        _fnDetectHeader( oSettings.aoHeader, thead );
-    }
+	if ( createHeader ) {
+		_fnDetectHeader( oSettings.aoHeader, thead );
+	}
 
 	/* ARIA role for the rows */
-    $(thead).find('>tr').attr('role', 'row');
+ 	$(thead).find('>tr').attr('role', 'row');
 
 	/* Deal with the footer - add classes if required */
-    $(thead).find('>tr>th, >tr>td').addClass( classes.sHeaderTH );
-    $(tfoot).find('>tr>th, >tr>td').addClass( classes.sFooterTH );
+	$(thead).find('>tr>th, >tr>td').addClass( classes.sHeaderTH );
+	$(tfoot).find('>tr>th, >tr>td').addClass( classes.sFooterTH );
 
-    // Cache the footer cells. Note that we only take the cells from the first
-    // row in the footer. If there is more than one row the user wants to
-    // interact with, they need to use the table().foot() method. Note also this
-    // allows cells to be used for multiple columns using colspan
-    if ( tfoot !== null ) {
-        var cells = oSettings.aoFooter[0];
+	// Cache the footer cells. Note that we only take the cells from the first
+	// row in the footer. If there is more than one row the user wants to
+	// interact with, they need to use the table().foot() method. Note also this
+	// allows cells to be used for multiple columns using colspan
+	if ( tfoot !== null ) {
+		var cells = oSettings.aoFooter[0];
 
-        for ( i=0, ien=cells.length ; i<ien ; i++ ) {
-            column = columns[i];
-            column.nTf = cells[i].cell;
+		for ( i=0, ien=cells.length ; i<ien ; i++ ) {
+			column = columns[i];
+			column.nTf = cells[i].cell;
 
-            if ( column.sClass ) {
-                $(column.nTf).addClass( column.sClass );
-            }
-        }
-    }
+			if ( column.sClass ) {
+				$(column.nTf).addClass( column.sClass );
+			}
+		}
+	}
 }
 
 
@@ -220,94 +220,94 @@ function _fnBuildHead( oSettings )
  */
 function _fnDrawHead( oSettings, aoSource, bIncludeHidden )
 {
-    var i, iLen, j, jLen, k, kLen, n, nLocalTr;
-    var aoLocal = [];
-    var aApplied = [];
-    var iColumns = oSettings.aoColumns.length;
-    var iRowspan, iColspan;
+	var i, iLen, j, jLen, k, kLen, n, nLocalTr;
+	var aoLocal = [];
+	var aApplied = [];
+	var iColumns = oSettings.aoColumns.length;
+	var iRowspan, iColspan;
 
-    if ( ! aoSource )
-    {
-        return;
-    }
+	if ( ! aoSource )
+	{
+		return;
+	}
 
-    if (  bIncludeHidden === undefined )
-    {
-        bIncludeHidden = false;
-    }
+	if (  bIncludeHidden === undefined )
+	{
+		bIncludeHidden = false;
+	}
 
 	/* Make a copy of the master layout array, but without the visible columns in it */
-    for ( i=0, iLen=aoSource.length ; i<iLen ; i++ )
-    {
-        aoLocal[i] = aoSource[i].slice();
-        aoLocal[i].nTr = aoSource[i].nTr;
+	for ( i=0, iLen=aoSource.length ; i<iLen ; i++ )
+	{
+		aoLocal[i] = aoSource[i].slice();
+		aoLocal[i].nTr = aoSource[i].nTr;
 
 		/* Remove any columns which are currently hidden */
-        for ( j=iColumns-1 ; j>=0 ; j-- )
-        {
-            if ( !oSettings.aoColumns[j].bVisible && !bIncludeHidden )
-            {
-                aoLocal[i].splice( j, 1 );
-            }
-        }
+		for ( j=iColumns-1 ; j>=0 ; j-- )
+		{
+			if ( !oSettings.aoColumns[j].bVisible && !bIncludeHidden )
+			{
+				aoLocal[i].splice( j, 1 );
+			}
+		}
 
 		/* Prep the applied array - it needs an element for each row */
-        aApplied.push( [] );
-    }
+		aApplied.push( [] );
+	}
 
-    for ( i=0, iLen=aoLocal.length ; i<iLen ; i++ )
-    {
-        nLocalTr = aoLocal[i].nTr;
+	for ( i=0, iLen=aoLocal.length ; i<iLen ; i++ )
+	{
+		nLocalTr = aoLocal[i].nTr;
 
 		/* All cells are going to be replaced, so empty out the row */
-        if ( nLocalTr )
-        {
-            while( (n = nLocalTr.firstChild) )
-            {
-                nLocalTr.removeChild( n );
-            }
-        }
+		if ( nLocalTr )
+		{
+			while( (n = nLocalTr.firstChild) )
+			{
+				nLocalTr.removeChild( n );
+			}
+		}
 
-        for ( j=0, jLen=aoLocal[i].length ; j<jLen ; j++ )
-        {
-            iRowspan = 1;
-            iColspan = 1;
+		for ( j=0, jLen=aoLocal[i].length ; j<jLen ; j++ )
+		{
+			iRowspan = 1;
+			iColspan = 1;
 
 			/* Check to see if there is already a cell (row/colspan) covering our target
 			 * insert point. If there is, then there is nothing to do.
 			 */
-            if ( aApplied[i][j] === undefined )
-            {
-                nLocalTr.appendChild( aoLocal[i][j].cell );
-                aApplied[i][j] = 1;
+			if ( aApplied[i][j] === undefined )
+			{
+				nLocalTr.appendChild( aoLocal[i][j].cell );
+				aApplied[i][j] = 1;
 
 				/* Expand the cell to cover as many rows as needed */
-                while ( aoLocal[i+iRowspan] !== undefined &&
-                aoLocal[i][j].cell == aoLocal[i+iRowspan][j].cell )
-                {
-                    aApplied[i+iRowspan][j] = 1;
-                    iRowspan++;
-                }
+				while ( aoLocal[i+iRowspan] !== undefined &&
+				        aoLocal[i][j].cell == aoLocal[i+iRowspan][j].cell )
+				{
+					aApplied[i+iRowspan][j] = 1;
+					iRowspan++;
+				}
 
 				/* Expand the cell to cover as many columns as needed */
-                while ( aoLocal[i][j+iColspan] !== undefined &&
-                aoLocal[i][j].cell == aoLocal[i][j+iColspan].cell )
-                {
+				while ( aoLocal[i][j+iColspan] !== undefined &&
+				        aoLocal[i][j].cell == aoLocal[i][j+iColspan].cell )
+				{
 					/* Must update the applied array over the rows for the columns */
-                    for ( k=0 ; k<iRowspan ; k++ )
-                    {
-                        aApplied[i+k][j+iColspan] = 1;
-                    }
-                    iColspan++;
-                }
+					for ( k=0 ; k<iRowspan ; k++ )
+					{
+						aApplied[i+k][j+iColspan] = 1;
+					}
+					iColspan++;
+				}
 
 				/* Do the actual expansion in the DOM */
-                $(aoLocal[i][j].cell)
-                    .attr('rowspan', iRowspan)
-                    .attr('colspan', iColspan);
-            }
-        }
-    }
+				$(aoLocal[i][j].cell)
+					.attr('rowspan', iRowspan)
+					.attr('colspan', iColspan);
+			}
+		}
+	}
 }
 
 
@@ -319,134 +319,134 @@ function _fnDrawHead( oSettings, aoSource, bIncludeHidden )
 function _fnDraw( oSettings )
 {
 	/* Provide a pre-callback function which can be used to cancel the draw is false is returned */
-    var aPreDraw = _fnCallbackFire( oSettings, 'aoPreDrawCallback', 'preDraw', [oSettings] );
-    if ( $.inArray( false, aPreDraw ) !== -1 )
-    {
-        _fnProcessingDisplay( oSettings, false );
-        return;
-    }
+	var aPreDraw = _fnCallbackFire( oSettings, 'aoPreDrawCallback', 'preDraw', [oSettings] );
+	if ( $.inArray( false, aPreDraw ) !== -1 )
+	{
+		_fnProcessingDisplay( oSettings, false );
+		return;
+	}
 
-    var i, iLen, n;
-    var anRows = [];
-    var iRowCount = 0;
-    var asStripeClasses = oSettings.asStripeClasses;
-    var iStripes = asStripeClasses.length;
-    var iOpenRows = oSettings.aoOpenRows.length;
-    var oLang = oSettings.oLanguage;
-    var iInitDisplayStart = oSettings.iInitDisplayStart;
-    var bServerSide = _fnDataSource( oSettings ) == 'ssp';
-    var aiDisplay = oSettings.aiDisplay;
+	var i, iLen, n;
+	var anRows = [];
+	var iRowCount = 0;
+	var asStripeClasses = oSettings.asStripeClasses;
+	var iStripes = asStripeClasses.length;
+	var iOpenRows = oSettings.aoOpenRows.length;
+	var oLang = oSettings.oLanguage;
+	var iInitDisplayStart = oSettings.iInitDisplayStart;
+	var bServerSide = _fnDataSource( oSettings ) == 'ssp';
+	var aiDisplay = oSettings.aiDisplay;
 
-    oSettings.bDrawing = true;
+	oSettings.bDrawing = true;
 
 	/* Check and see if we have an initial draw position from state saving */
-    if ( iInitDisplayStart !== undefined && iInitDisplayStart !== -1 )
-    {
-        oSettings._iDisplayStart = bServerSide ?
-            iInitDisplayStart :
-            iInitDisplayStart >= oSettings.fnRecordsDisplay() ?
-                0 :
-                iInitDisplayStart;
+	if ( iInitDisplayStart !== undefined && iInitDisplayStart !== -1 )
+	{
+		oSettings._iDisplayStart = bServerSide ?
+			iInitDisplayStart :
+			iInitDisplayStart >= oSettings.fnRecordsDisplay() ?
+				0 :
+				iInitDisplayStart;
 
-        oSettings.iInitDisplayStart = -1;
-    }
+		oSettings.iInitDisplayStart = -1;
+	}
 
-    var iDisplayStart = oSettings._iDisplayStart;
-    var iDisplayEnd = oSettings.fnDisplayEnd();
+	var iDisplayStart = oSettings._iDisplayStart;
+	var iDisplayEnd = oSettings.fnDisplayEnd();
 
 	/* Server-side processing draw intercept */
-    if ( oSettings.bDeferLoading )
-    {
-        oSettings.bDeferLoading = false;
-        oSettings.iDraw++;
-        _fnProcessingDisplay( oSettings, false );
-    }
-    else if ( !bServerSide )
-    {
-        oSettings.iDraw++;
-    }
-    else if ( !oSettings.bDestroying && !_fnAjaxUpdate( oSettings ) )
-    {
-        return;
-    }
+	if ( oSettings.bDeferLoading )
+	{
+		oSettings.bDeferLoading = false;
+		oSettings.iDraw++;
+		_fnProcessingDisplay( oSettings, false );
+	}
+	else if ( !bServerSide )
+	{
+		oSettings.iDraw++;
+	}
+	else if ( !oSettings.bDestroying && !_fnAjaxUpdate( oSettings ) )
+	{
+		return;
+	}
 
-    if ( aiDisplay.length !== 0 )
-    {
-        var iStart = bServerSide ? 0 : iDisplayStart;
-        var iEnd = bServerSide ? oSettings.aoData.length : iDisplayEnd;
+	if ( aiDisplay.length !== 0 )
+	{
+		var iStart = bServerSide ? 0 : iDisplayStart;
+		var iEnd = bServerSide ? oSettings.aoData.length : iDisplayEnd;
 
-        for ( var j=iStart ; j<iEnd ; j++ )
-        {
-            var iDataIndex = aiDisplay[j];
-            var aoData = oSettings.aoData[ iDataIndex ];
-            if ( aoData.nTr === null )
-            {
-                _fnCreateTr( oSettings, iDataIndex );
-            }
+		for ( var j=iStart ; j<iEnd ; j++ )
+		{
+			var iDataIndex = aiDisplay[j];
+			var aoData = oSettings.aoData[ iDataIndex ];
+			if ( aoData.nTr === null )
+			{
+				_fnCreateTr( oSettings, iDataIndex );
+			}
 
-            var nRow = aoData.nTr;
+			var nRow = aoData.nTr;
 
 			/* Remove the old striping classes and then add the new one */
-            if ( iStripes !== 0 )
-            {
-                var sStripe = asStripeClasses[ iRowCount % iStripes ];
-                if ( aoData._sRowStripe != sStripe )
-                {
-                    $(nRow).removeClass( aoData._sRowStripe ).addClass( sStripe );
-                    aoData._sRowStripe = sStripe;
-                }
-            }
+			if ( iStripes !== 0 )
+			{
+				var sStripe = asStripeClasses[ iRowCount % iStripes ];
+				if ( aoData._sRowStripe != sStripe )
+				{
+					$(nRow).removeClass( aoData._sRowStripe ).addClass( sStripe );
+					aoData._sRowStripe = sStripe;
+				}
+			}
 
-            // Row callback functions - might want to manipulate the row
-            // iRowCount and j are not currently documented. Are they at all
-            // useful?
-            _fnCallbackFire( oSettings, 'aoRowCallback', null,
-                [nRow, aoData._aData, iRowCount, j] );
+			// Row callback functions - might want to manipulate the row
+			// iRowCount and j are not currently documented. Are they at all
+			// useful?
+			_fnCallbackFire( oSettings, 'aoRowCallback', null,
+				[nRow, aoData._aData, iRowCount, j] );
 
-            anRows.push( nRow );
-            iRowCount++;
-        }
-    }
-    else
-    {
+			anRows.push( nRow );
+			iRowCount++;
+		}
+	}
+	else
+	{
 		/* Table is empty - create a row with an empty message in it */
-        var sZero = oLang.sZeroRecords;
-        if ( oSettings.iDraw == 1 &&  _fnDataSource( oSettings ) == 'ajax' )
-        {
-            sZero = oLang.sLoadingRecords;
-        }
-        else if ( oLang.sEmptyTable && oSettings.fnRecordsTotal() === 0 )
-        {
-            sZero = oLang.sEmptyTable;
-        }
+		var sZero = oLang.sZeroRecords;
+		if ( oSettings.iDraw == 1 &&  _fnDataSource( oSettings ) == 'ajax' )
+		{
+			sZero = oLang.sLoadingRecords;
+		}
+		else if ( oLang.sEmptyTable && oSettings.fnRecordsTotal() === 0 )
+		{
+			sZero = oLang.sEmptyTable;
+		}
 
-        anRows[ 0 ] = $( '<tr/>', { 'class': iStripes ? asStripeClasses[0] : '' } )
-            .append( $('<td />', {
-                'valign':  'top',
-                'colSpan': _fnVisbleColumns( oSettings ),
-                'class':   oSettings.oClasses.sRowEmpty
-            } ).html( sZero ) )[0];
-    }
+		anRows[ 0 ] = $( '<tr/>', { 'class': iStripes ? asStripeClasses[0] : '' } )
+			.append( $('<td />', {
+				'valign':  'top',
+				'colSpan': _fnVisbleColumns( oSettings ),
+				'class':   oSettings.oClasses.sRowEmpty
+			} ).html( sZero ) )[0];
+	}
 
 	/* Header and footer callbacks */
-    _fnCallbackFire( oSettings, 'aoHeaderCallback', 'header', [ $(oSettings.nTHead).children('tr')[0],
-        _fnGetDataMaster( oSettings ), iDisplayStart, iDisplayEnd, aiDisplay ] );
+	_fnCallbackFire( oSettings, 'aoHeaderCallback', 'header', [ $(oSettings.nTHead).children('tr')[0],
+		_fnGetDataMaster( oSettings ), iDisplayStart, iDisplayEnd, aiDisplay ] );
 
-    _fnCallbackFire( oSettings, 'aoFooterCallback', 'footer', [ $(oSettings.nTFoot).children('tr')[0],
-        _fnGetDataMaster( oSettings ), iDisplayStart, iDisplayEnd, aiDisplay ] );
+	_fnCallbackFire( oSettings, 'aoFooterCallback', 'footer', [ $(oSettings.nTFoot).children('tr')[0],
+		_fnGetDataMaster( oSettings ), iDisplayStart, iDisplayEnd, aiDisplay ] );
 
-    var body = $(oSettings.nTBody);
+	var body = $(oSettings.nTBody);
 
-    body.children().detach();
-    body.append( $(anRows) );
+	body.children().detach();
+	body.append( $(anRows) );
 
 	/* Call all required callback functions for the end of a draw */
-    _fnCallbackFire( oSettings, 'aoDrawCallback', 'draw', [oSettings] );
+	_fnCallbackFire( oSettings, 'aoDrawCallback', 'draw', [oSettings] );
 
 	/* Draw is complete, sorting and filtering must be as well */
-    oSettings.bSorted = false;
-    oSettings.bFiltered = false;
-    oSettings.bDrawing = false;
+	oSettings.bSorted = false;
+	oSettings.bFiltered = false;
+	oSettings.bDrawing = false;
 }
 
 
@@ -459,34 +459,34 @@ function _fnDraw( oSettings )
  */
 function _fnReDraw( settings, holdPosition )
 {
-    var
-        features = settings.oFeatures,
-        sort     = features.bSort,
-        filter   = features.bFilter;
+	var
+		features = settings.oFeatures,
+		sort     = features.bSort,
+		filter   = features.bFilter;
 
-    if ( sort ) {
-        _fnSort( settings );
-    }
+	if ( sort ) {
+		_fnSort( settings );
+	}
 
-    if ( filter ) {
-        _fnFilterComplete( settings, settings.oPreviousSearch );
-    }
-    else {
-        // No filtering, so we want to just use the display master
-        settings.aiDisplay = settings.aiDisplayMaster.slice();
-    }
+	if ( filter ) {
+		_fnFilterComplete( settings, settings.oPreviousSearch );
+	}
+	else {
+		// No filtering, so we want to just use the display master
+		settings.aiDisplay = settings.aiDisplayMaster.slice();
+	}
 
-    if ( holdPosition !== true ) {
-        settings._iDisplayStart = 0;
-    }
+	if ( holdPosition !== true ) {
+		settings._iDisplayStart = 0;
+	}
 
-    // Let any modules know about the draw hold position state (used by
-    // scrolling internally)
-    settings._drawHold = holdPosition;
+	// Let any modules know about the draw hold position state (used by
+	// scrolling internally)
+	settings._drawHold = holdPosition;
 
-    _fnDraw( settings );
+	_fnDraw( settings );
 
-    settings._drawHold = false;
+	settings._drawHold = false;
 }
 
 
@@ -497,153 +497,148 @@ function _fnReDraw( settings, holdPosition )
  */
 function _fnAddOptionsHtml ( oSettings )
 {
-    var classes = oSettings.oClasses;
-    var table = $(oSettings.nTable);
-    var holding = $('<div/>').insertBefore( table ); // Holding element for speed
-    var features = oSettings.oFeatures;
+	var classes = oSettings.oClasses;
+	var table = $(oSettings.nTable);
+	var holding = $('<div/>').insertBefore( table ); // Holding element for speed
+	var features = oSettings.oFeatures;
 
-    // All DataTables are wrapped in a div
-    var insert = $('<div/>', {
-        id:      oSettings.sTableId+'_wrapper',
-        'class': classes.sWrapper + (oSettings.nTFoot ? '' : ' '+classes.sNoFooter)
-    } );
+	// All DataTables are wrapped in a div
+	var insert = $('<div/>', {
+		id:      oSettings.sTableId+'_wrapper',
+		'class': classes.sWrapper + (oSettings.nTFoot ? '' : ' '+classes.sNoFooter)
+	} );
 
-    oSettings.nHolding = holding[0];
-    oSettings.nTableWrapper = insert[0];
-    oSettings.nTableReinsertBefore = oSettings.nTable.nextSibling;
+	oSettings.nHolding = holding[0];
+	oSettings.nTableWrapper = insert[0];
+	oSettings.nTableReinsertBefore = oSettings.nTable.nextSibling;
 
 	/* Loop over the user set positioning and place the elements as needed */
-    var aDom = oSettings.sDom.split('');
-    var featureNode, cOption, nNewNode, cNext, sAttr, j;
-    for ( var i=0 ; i<aDom.length ; i++ )
-    {
-        featureNode = null;
-        cOption = aDom[i];
+	var aDom = oSettings.sDom.split('');
+	var featureNode, cOption, nNewNode, cNext, sAttr, j;
+	for ( var i=0 ; i<aDom.length ; i++ )
+	{
+		featureNode = null;
+		cOption = aDom[i];
 
-        if ( cOption == '<' )
-        {
+		if ( cOption == '<' )
+		{
 			/* New container div */
-            nNewNode = $('<div/>')[0];
+			nNewNode = $('<div/>')[0];
 
 			/* Check to see if we should append an id and/or a class name to the container */
-            cNext = aDom[i+1];
-            if ( cNext == "'" || cNext == '"' )
-            {
-                sAttr = "";
-                j = 2;
-                while ( aDom[i+j] != cNext )
-                {
-                    sAttr += aDom[i+j];
-                    j++;
-                }
+			cNext = aDom[i+1];
+			if ( cNext == "'" || cNext == '"' )
+			{
+				sAttr = "";
+				j = 2;
+				while ( aDom[i+j] != cNext )
+				{
+					sAttr += aDom[i+j];
+					j++;
+				}
 
 				/* Replace jQuery UI constants @todo depreciated */
-                if ( sAttr == "H" )
-                {
-                    sAttr = classes.sJUIHeader;
-                }
-                else if ( sAttr == "F" )
-                {
-                    sAttr = classes.sJUIFooter;
-                }
+				if ( sAttr == "H" )
+				{
+					sAttr = classes.sJUIHeader;
+				}
+				else if ( sAttr == "F" )
+				{
+					sAttr = classes.sJUIFooter;
+				}
 
 				/* The attribute can be in the format of "#id.class", "#id" or "class" This logic
 				 * breaks the string into parts and applies them as needed
 				 */
-                if ( sAttr.indexOf('.') != -1 )
-                {
-                    var aSplit = sAttr.split('.');
-                    nNewNode.id = aSplit[0].substr(1, aSplit[0].length-1);
-                    nNewNode.className = aSplit[1];
-                }
-                else if ( sAttr.charAt(0) == "#" )
-                {
-                    nNewNode.id = sAttr.substr(1, sAttr.length-1);
-                }
-                else
-                {
-                    nNewNode.className = sAttr;
-                }
+				if ( sAttr.indexOf('.') != -1 )
+				{
+					var aSplit = sAttr.split('.');
+					nNewNode.id = aSplit[0].substr(1, aSplit[0].length-1);
+					nNewNode.className = aSplit[1];
+				}
+				else if ( sAttr.charAt(0) == "#" )
+				{
+					nNewNode.id = sAttr.substr(1, sAttr.length-1);
+				}
+				else
+				{
+					nNewNode.className = sAttr;
+				}
 
-                i += j; /* Move along the position array */
-            }
+				i += j; /* Move along the position array */
+			}
 
-            insert.append( nNewNode );
-            insert = $(nNewNode);
-        }
-        else if ( cOption == '>' )
-        {
+			insert.append( nNewNode );
+			insert = $(nNewNode);
+		}
+		else if ( cOption == '>' )
+		{
 			/* End container div */
-            insert = insert.parent();
-        }
-        // @todo Move options into their own plugins?
-        else if ( cOption == 'l' && features.bPaginate && features.bLengthChange )
-        {
+			insert = insert.parent();
+		}
+		// @todo Move options into their own plugins?
+		else if ( cOption == 'l' && features.bPaginate && features.bLengthChange )
+		{
 			/* Length */
-            featureNode = _fnFeatureHtmlLength( oSettings );
-        }
-        else if ( cOption == 'e' && features.bExclude )
-        {
-			/* Exclude */
-            featureNode = _fnFeatureHtmlExclude( oSettings );
-        }
-        else if ( cOption == 'f' && features.bFilter )
-        {
+			featureNode = _fnFeatureHtmlLength( oSettings );
+		}
+		else if ( cOption == 'f' && features.bFilter )
+		{
 			/* Filter */
-            featureNode = _fnFeatureHtmlFilter( oSettings );
-        }
-        else if ( cOption == 'r' && features.bProcessing )
-        {
+			featureNode = _fnFeatureHtmlFilter( oSettings );
+		}
+		else if ( cOption == 'r' && features.bProcessing )
+		{
 			/* pRocessing */
-            featureNode = _fnFeatureHtmlProcessing( oSettings );
-        }
-        else if ( cOption == 't' )
-        {
+			featureNode = _fnFeatureHtmlProcessing( oSettings );
+		}
+		else if ( cOption == 't' )
+		{
 			/* Table */
-            featureNode = _fnFeatureHtmlTable( oSettings );
-        }
-        else if ( cOption ==  'i' && features.bInfo )
-        {
+			featureNode = _fnFeatureHtmlTable( oSettings );
+		}
+		else if ( cOption ==  'i' && features.bInfo )
+		{
 			/* Info */
-            featureNode = _fnFeatureHtmlInfo( oSettings );
-        }
-        else if ( cOption == 'p' && features.bPaginate )
-        {
+			featureNode = _fnFeatureHtmlInfo( oSettings );
+		}
+		else if ( cOption == 'p' && features.bPaginate )
+		{
 			/* Pagination */
-            featureNode = _fnFeatureHtmlPaginate( oSettings );
-        }
-        else if ( DataTable.ext.feature.length !== 0 )
-        {
+			featureNode = _fnFeatureHtmlPaginate( oSettings );
+		}
+		else if ( DataTable.ext.feature.length !== 0 )
+		{
 			/* Plug-in features */
-            var aoFeatures = DataTable.ext.feature;
-            for ( var k=0, kLen=aoFeatures.length ; k<kLen ; k++ )
-            {
-                if ( cOption == aoFeatures[k].cFeature )
-                {
-                    featureNode = aoFeatures[k].fnInit( oSettings );
-                    break;
-                }
-            }
-        }
+			var aoFeatures = DataTable.ext.feature;
+			for ( var k=0, kLen=aoFeatures.length ; k<kLen ; k++ )
+			{
+				if ( cOption == aoFeatures[k].cFeature )
+				{
+					featureNode = aoFeatures[k].fnInit( oSettings );
+					break;
+				}
+			}
+		}
 
 		/* Add to the 2D features array */
-        if ( featureNode )
-        {
-            var aanFeatures = oSettings.aanFeatures;
+		if ( featureNode )
+		{
+			var aanFeatures = oSettings.aanFeatures;
 
-            if ( ! aanFeatures[cOption] )
-            {
-                aanFeatures[cOption] = [];
-            }
+			if ( ! aanFeatures[cOption] )
+			{
+				aanFeatures[cOption] = [];
+			}
 
-            aanFeatures[cOption].push( featureNode );
-            insert.append( featureNode );
-        }
-    }
+			aanFeatures[cOption].push( featureNode );
+			insert.append( featureNode );
+		}
+	}
 
 	/* Built our DOM structure - replace the holding div with what we want */
-    holding.replaceWith( insert );
-    oSettings.nHolding = null;
+	holding.replaceWith( insert );
+	oSettings.nHolding = null;
 }
 
 
@@ -658,68 +653,68 @@ function _fnAddOptionsHtml ( oSettings )
  */
 function _fnDetectHeader ( aLayout, nThead )
 {
-    var nTrs = $(nThead).children('tr');
-    var nTr, nCell;
-    var i, k, l, iLen, jLen, iColShifted, iColumn, iColspan, iRowspan;
-    var bUnique;
-    var fnShiftCol = function ( a, i, j ) {
-        var k = a[i];
-        while ( k[j] ) {
-            j++;
-        }
-        return j;
-    };
+	var nTrs = $(nThead).children('tr');
+	var nTr, nCell;
+	var i, k, l, iLen, jLen, iColShifted, iColumn, iColspan, iRowspan;
+	var bUnique;
+	var fnShiftCol = function ( a, i, j ) {
+		var k = a[i];
+                while ( k[j] ) {
+			j++;
+		}
+		return j;
+	};
 
-    aLayout.splice( 0, aLayout.length );
+	aLayout.splice( 0, aLayout.length );
 
 	/* We know how many rows there are in the layout - so prep it */
-    for ( i=0, iLen=nTrs.length ; i<iLen ; i++ )
-    {
-        aLayout.push( [] );
-    }
+	for ( i=0, iLen=nTrs.length ; i<iLen ; i++ )
+	{
+		aLayout.push( [] );
+	}
 
 	/* Calculate a layout array */
-    for ( i=0, iLen=nTrs.length ; i<iLen ; i++ )
-    {
-        nTr = nTrs[i];
-        iColumn = 0;
+	for ( i=0, iLen=nTrs.length ; i<iLen ; i++ )
+	{
+		nTr = nTrs[i];
+		iColumn = 0;
 
 		/* For every cell in the row... */
-        nCell = nTr.firstChild;
-        while ( nCell ) {
-            if ( nCell.nodeName.toUpperCase() == "TD" ||
-                nCell.nodeName.toUpperCase() == "TH" )
-            {
+		nCell = nTr.firstChild;
+		while ( nCell ) {
+			if ( nCell.nodeName.toUpperCase() == "TD" ||
+			     nCell.nodeName.toUpperCase() == "TH" )
+			{
 				/* Get the col and rowspan attributes from the DOM and sanitise them */
-                iColspan = nCell.getAttribute('colspan') * 1;
-                iRowspan = nCell.getAttribute('rowspan') * 1;
-                iColspan = (!iColspan || iColspan===0 || iColspan===1) ? 1 : iColspan;
-                iRowspan = (!iRowspan || iRowspan===0 || iRowspan===1) ? 1 : iRowspan;
+				iColspan = nCell.getAttribute('colspan') * 1;
+				iRowspan = nCell.getAttribute('rowspan') * 1;
+				iColspan = (!iColspan || iColspan===0 || iColspan===1) ? 1 : iColspan;
+				iRowspan = (!iRowspan || iRowspan===0 || iRowspan===1) ? 1 : iRowspan;
 
 				/* There might be colspan cells already in this row, so shift our target
 				 * accordingly
 				 */
-                iColShifted = fnShiftCol( aLayout, i, iColumn );
+				iColShifted = fnShiftCol( aLayout, i, iColumn );
 
 				/* Cache calculation for unique columns */
-                bUnique = iColspan === 1 ? true : false;
+				bUnique = iColspan === 1 ? true : false;
 
 				/* If there is col / rowspan, copy the information into the layout grid */
-                for ( l=0 ; l<iColspan ; l++ )
-                {
-                    for ( k=0 ; k<iRowspan ; k++ )
-                    {
-                        aLayout[i+k][iColShifted+l] = {
-                            "cell": nCell,
-                            "unique": bUnique
-                        };
-                        aLayout[i+k].nTr = nTr;
-                    }
-                }
-            }
-            nCell = nCell.nextSibling;
-        }
-    }
+				for ( l=0 ; l<iColspan ; l++ )
+				{
+					for ( k=0 ; k<iRowspan ; k++ )
+					{
+						aLayout[i+k][iColShifted+l] = {
+							"cell": nCell,
+							"unique": bUnique
+						};
+						aLayout[i+k].nTr = nTr;
+					}
+				}
+			}
+			nCell = nCell.nextSibling;
+		}
+	}
 }
 
 
@@ -733,29 +728,29 @@ function _fnDetectHeader ( aLayout, nThead )
  */
 function _fnGetUniqueThs ( oSettings, nHeader, aLayout )
 {
-    var aReturn = [];
-    if ( !aLayout )
-    {
-        aLayout = oSettings.aoHeader;
-        if ( nHeader )
-        {
-            aLayout = [];
-            _fnDetectHeader( aLayout, nHeader );
-        }
-    }
+	var aReturn = [];
+	if ( !aLayout )
+	{
+		aLayout = oSettings.aoHeader;
+		if ( nHeader )
+		{
+			aLayout = [];
+			_fnDetectHeader( aLayout, nHeader );
+		}
+	}
 
-    for ( var i=0, iLen=aLayout.length ; i<iLen ; i++ )
-    {
-        for ( var j=0, jLen=aLayout[i].length ; j<jLen ; j++ )
-        {
-            if ( aLayout[i][j].unique &&
-                (!aReturn[j] || !oSettings.bSortCellsTop) )
-            {
-                aReturn[j] = aLayout[i][j].cell;
-            }
-        }
-    }
+	for ( var i=0, iLen=aLayout.length ; i<iLen ; i++ )
+	{
+		for ( var j=0, jLen=aLayout[i].length ; j<jLen ; j++ )
+		{
+			if ( aLayout[i][j].unique &&
+				 (!aReturn[j] || !oSettings.bSortCellsTop) )
+			{
+				aReturn[j] = aLayout[i][j].cell;
+			}
+		}
+	}
 
-    return aReturn;
+	return aReturn;
 }
 

--- a/js/core/core.exclude.js
+++ b/js/core/core.exclude.js
@@ -1,0 +1,374 @@
+
+/**
+ * Generate the node required for filtering text
+ *  @returns {node} Filter control exclude element
+ *  @param {object} settings dataTables settings object
+ *  @memberof DataTable#oApi
+ */
+function _fnFeatureHtmlExclude ( settings )
+{
+    var classes = settings.oClasses;
+    var tableId = settings.sTableId;
+    var language = settings.oLanguage;
+    var previousExclude = settings.oPreviousExclude;
+    var features = settings.aanFeatures;
+    var input = '<input type="search" class="'+classes.sFilterInput+'"/>';
+
+    var str = language.sSearch;
+    str = str.match(/_INPUT_/) ?
+        str.replace('_INPUT_', input) :
+        str+input;
+
+    var filter = $('<div/>', {
+        'id': ! features.f ? tableId+'_filter' : null,
+        'class': classes.sFilter
+    } )
+        .append( $('<label/>' ).append( str ) );
+
+    var searchFn = function() {
+        /* Update all other filter input elements for the new display */
+        var n = features.f;
+        var val = !this.value ? "" : this.value; // mental IE8 fix :-(
+
+        /* Now do the filter */
+        if ( val !== previousExclude.sSearch ) {
+            _fnExcludeComplete( settings, {
+                "sSearch": val,
+                "bRegex": previousExclude.bRegex,
+                "bSmart": previousExclude.bSmart ,
+                "bCaseInsensitive": previousExclude.bCaseInsensitive
+            } );
+
+            // Need to redraw, without resorting
+            settings._iDisplayStart = 0;
+            _fnDraw( settings );
+        }
+    };
+
+    var searchDelay = settings.searchDelay !== null ?
+        settings.searchDelay :
+        _fnDataSource( settings ) === 'ssp' ?
+            400 :
+            0;
+
+    var jqFilter = $('input', filter)
+        .val( previousExclude.sSearch )
+        .attr( 'placeholder', language.sSearchPlaceholder )
+        .on(
+            'keyup.DT search.DT input.DT paste.DT cut.DT',
+            searchDelay ?
+                _fnThrottle( searchFn, searchDelay ) :
+                searchFn
+        )
+        .on( 'keypress.DT', function(e) {
+            /* Prevent form submission */
+            if ( e.keyCode === 13 ) {
+                return false;
+            }
+        } )
+        .attr('aria-controls', tableId);
+
+    // Update the input elements whenever the table is filtered
+    $(settings.nTable).on( 'search.dt.DT', function ( ev, s ) {
+        if ( settings === s ) {
+            // IE9 throws an 'unknown error' if document.activeElement is used
+            // inside an iframe or frame...
+            try {
+                if ( jqFilter[0] !== document.activeElement ) {
+                    jqFilter.val( previousExclude.sSearch );
+                }
+            }
+            catch ( e ) {}
+        }
+    } );
+
+    return filter[0];
+}
+
+
+/**
+ * Filter the table using both the global filter and column based filtering
+ *  @param {object} oSettings dataTables settings object
+ *  @param {object} oExclude search information
+ *  @param {int} [iForce] force a research of the master array (1) or not (undefined or 0)
+ *  @memberof DataTable#oApi
+ */
+function _fnExcludeComplete ( oSettings, oExclude, iForce )
+{
+    var oPrevExclude = oSettings.oPreviousExclude;
+    var fnSaveExclude = function ( oExclude ) {
+        /* Save the filtering values */
+        oPrevExclude.sSearch = oExclude.sSearch;
+        oPrevExclude.bRegex = oExclude.bRegex;
+        oPrevExclude.bSmart = oExclude.bSmart;
+        oPrevExclude.bCaseInsensitive = oExclude.bCaseInsensitive;
+    };
+    var fnRegex = function ( o ) {
+        // Backwards compatibility with the bEscapeRegex option
+        return o.bEscapeRegex !== undefined ? !o.bEscapeRegex : o.bRegex;
+    };
+
+    // Resolve any column types that are unknown due to addition or invalidation
+    // @todo As per sort - can this be moved into an event handler?
+    _fnColumnTypes( oSettings );
+
+    /* In server-side processing all filtering is done by the server, so no point hanging around here */
+    if ( _fnDataSource( oSettings ) !== 'ssp' )
+    {
+        /* Global filter */
+        _fnExclude( oSettings, oExclude.sSearch, iForce, fnRegex(oInput), oExclude.bSmart, oExclude.bCaseInsensitive );
+        fnSaveExclude( oInput );
+    }
+    else
+    {
+        fnSaveExclude( oInput );
+    }
+
+    /* Tell the draw function we have been filtering */
+    oSettings.bFiltered = true;
+    _fnCallbackFire( oSettings, null, 'search', [oSettings] );
+}
+
+
+/**
+ * Apply custom filtering functions
+ *  @param {object} settings dataTables settings object
+ *  @memberof DataTable#oApi
+ */
+function _fnExcludeCustom( settings )
+{
+    var filters = DataTable.ext.search;
+    var displayRows = settings.aiDisplay;
+    var row, rowIdx;
+
+    for ( var i=0, ien=filters.length ; i<ien ; i++ ) {
+        var rows = [];
+
+        // Loop over each row and see if it should be included
+        for ( var j=0, jen=displayRows.length ; j<jen ; j++ ) {
+            rowIdx = displayRows[ j ];
+            row = settings.aoData[ rowIdx ];
+
+            if ( filters[i]( settings, row._aFilterData, rowIdx, row._aData, j ) ) {
+                rows.push( rowIdx );
+            }
+        }
+
+        // So the array reference doesn't break set the results into the
+        // existing array
+        displayRows.length = 0;
+        $.merge( displayRows, rows );
+    }
+}
+
+
+
+/**
+ * Filter (via exclude) the data table based on user input and draw the table
+ *  @param {object} settings dataTables settings object
+ *  @param {string} input string to filter on
+ *  @param {int} force optional - force a research of the master array (1) or not (undefined or 0)
+ *  @param {bool} regex treat as a regular expression or not
+ *  @param {bool} smart perform smart filtering or not
+ *  @param {bool} caseInsensitive Do case insenstive matching or not
+ *  @memberof DataTable#oApi
+ */
+function _fnExclude( settings, input, force, regex, smart, caseInsensitive )
+{
+    var rpExclude = _fnFilterCreateExclude( input, regex, smart, caseInsensitive );
+    var prevExclude = settings.oPreviousExclude.sSearch;
+    var displayMaster = settings.aiDisplayMaster;
+    var display, invalidated, i;
+    var filtered = [];
+
+    // Need to take account of custom filtering functions - always filter
+    if ( DataTable.ext.search.length !== 0 ) {
+        force = true;
+    }
+
+    // Check if any of the rows were invalidated
+    invalidated = _fnExcludeData( settings );
+
+    // If the input is blank - we just want the full data set
+    if ( input.length <= 0 ) {
+        settings.aiDisplay = displayMaster.slice();
+    }
+    else {
+        // New search - start from the master array
+        if ( invalidated ||
+            force ||
+            prevExclude.length > input.length ||
+            input.indexOf(prevExclude) !== 0 ||
+            settings.bSorted // On resort, the display master needs to be
+                             // re-filtered since indexes will have changed
+        ) {
+            settings.aiDisplay = displayMaster.slice();
+        }
+
+        // Exclude the display array
+        display = settings.aiDisplay;
+
+        for ( i=0 ; i<display.length ; i++ ) {
+            if ( !rpExclude.test( settings.aoData[ display[i] ]._sFilterRow ) ) {
+                filtered.push( display[i] );
+            }
+        }
+
+        settings.aiDisplay = filtered;
+    }
+}
+
+
+/**
+ * Build a regular expression object suitable for searching a table
+ *  @param {string} search string to search for
+ *  @param {bool} regex treat as a regular expression or not
+ *  @param {bool} smart perform smart filtering or not
+ *  @param {bool} caseInsensitive Do case insensitive matching or not
+ *  @returns {RegExp} constructed object
+ *  @memberof DataTable#oApi
+ */
+function _fnFilterCreateExclude( search, regex, smart, caseInsensitive )
+{
+    search = regex ?
+        search :
+        _fnEscapeRegex( search );
+
+    if ( smart ) {
+        /* For smart filtering we want to allow the search to work regardless of
+         * word order. We also want double quoted text to be preserved, so word
+         * order is important - a la google. So this is what we want to
+         * generate:
+         *
+         * ^(?=.*?\bone\b)(?=.*?\btwo three\b)(?=.*?\bfour\b).*$
+         */
+        var a = $.map( search.match( /"[^"]+"|[^ ]+/g ) || [''], function ( word ) {
+            if ( word.charAt(0) === '"' ) {
+                var m = word.match( /^"(.*)"$/ );
+                word = m ? m[1] : word;
+            }
+
+            return word.replace('"', '');
+        } );
+
+        search = '^(?=.*?'+a.join( ')(?=.*?' )+').*$';
+    }
+
+    return new RegExp( search, caseInsensitive ? 'i' : '' );
+}
+
+
+/**
+ * Escape a string such that it can be used in a regular expression
+ *  @param {string} sVal string to escape
+ *  @returns {string} escaped string
+ *  @memberof DataTable#oApi
+ */
+var _fnEscapeRegex = DataTable.util.escapeRegex;
+
+var __filter_div = $('<div>')[0];
+var __filter_div_textContent = __filter_div.textContent !== undefined;
+
+// Update the filtering data for each row if needed (by invalidation or first run)
+function _fnExcludeData ( settings )
+{
+    var columns = settings.aoColumns;
+    var column;
+    var i, j, ien, jen, filterData, cellData, row;
+    var fomatters = DataTable.ext.type.search;
+    var wasInvalidated = false;
+
+    for ( i=0, ien=settings.aoData.length ; i<ien ; i++ ) {
+        row = settings.aoData[i];
+
+        if ( ! row._aFilterData ) {
+            filterData = [];
+
+            for ( j=0, jen=columns.length ; j<jen ; j++ ) {
+                column = columns[j];
+
+                if ( column.bSearchable ) {
+                    cellData = _fnGetCellData( settings, i, j, 'filter' );
+
+                    if ( fomatters[ column.sType ] ) {
+                        cellData = fomatters[ column.sType ]( cellData );
+                    }
+
+                    // Exclude in DataTables 1.10 is string based. In 1.11 this
+                    // should be altered to also allow strict type checking.
+                    if ( cellData === null ) {
+                        cellData = '';
+                    }
+
+                    if ( typeof cellData !== 'string' && cellData.toString ) {
+                        cellData = cellData.toString();
+                    }
+                }
+                else {
+                    cellData = '';
+                }
+
+                // If it looks like there is an HTML entity in the string,
+                // attempt to decode it so sorting works as expected. Note that
+                // we could use a single line of jQuery to do this, but the DOM
+                // method used here is much faster http://jsperf.com/html-decode
+                if ( cellData.indexOf && cellData.indexOf('&') !== -1 ) {
+                    __filter_div.innerHTML = cellData;
+                    cellData = __filter_div_textContent ?
+                        __filter_div.textContent :
+                        __filter_div.innerText;
+                }
+
+                if ( cellData.replace ) {
+                    cellData = cellData.replace(/[\r\n]/g, '');
+                }
+
+                filterData.push( cellData );
+            }
+
+            row._aFilterData = filterData;
+            row._sFilterRow = filterData.join('  ');
+            wasInvalidated = true;
+        }
+    }
+
+    return wasInvalidated;
+}
+
+
+/**
+ * Convert from the internal Hungarian notation to camelCase for external
+ * interaction
+ *  @param {object} obj Object to convert
+ *  @returns {object} Inverted object
+ *  @memberof DataTable#oApi
+ */
+function _fnExcludeToCamel ( obj )
+{
+    return {
+        search:          obj.sSearch,
+        smart:           obj.bSmart,
+        regex:           obj.bRegex,
+        caseInsensitive: obj.bCaseInsensitive
+    };
+}
+
+
+
+/**
+ * Convert from camelCase notation to the internal Hungarian. We could use the
+ * Hungarian convert function here, but this is cleaner
+ *  @param {object} obj Object to convert
+ *  @returns {object} Inverted object
+ *  @memberof DataTable#oApi
+ */
+function _fnExcludeToHung ( obj )
+{
+    return {
+        sSearch:          obj.search,
+        bSmart:           obj.smart,
+        bRegex:           obj.regex,
+        bCaseInsensitive: obj.caseInsensitive
+    };
+}
+

--- a/js/core/core.state.js
+++ b/js/core/core.state.js
@@ -7,30 +7,31 @@
  */
 function _fnSaveState ( settings )
 {
-	if ( !settings.oFeatures.bStateSave || settings.bDestroying )
-	{
-		return;
-	}
+    if ( !settings.oFeatures.bStateSave || settings.bDestroying )
+    {
+        return;
+    }
 
 	/* Store the interesting variables */
-	var state = {
-		time:    +new Date(),
-		start:   settings._iDisplayStart,
-		length:  settings._iDisplayLength,
-		order:   $.extend( true, [], settings.aaSorting ),
-		search:  _fnSearchToCamel( settings.oPreviousSearch ),
-		columns: $.map( settings.aoColumns, function ( col, i ) {
-			return {
-				visible: col.bVisible,
-				search: _fnSearchToCamel( settings.aoPreSearchCols[i] )
-			};
-		} )
-	};
+    var state = {
+        time:    +new Date(),
+        start:   settings._iDisplayStart,
+        length:  settings._iDisplayLength,
+        order:   $.extend( true, [], settings.aaSorting ),
+        search:  _fnSearchToCamel( settings.oPreviousSearch ),
+        exclude: _fnExcludeToCamel( settings.oPreviousExclude ),
+        columns: $.map( settings.aoColumns, function ( col, i ) {
+            return {
+                visible: col.bVisible,
+                search: _fnSearchToCamel( settings.aoPreSearchCols[i] )
+            };
+        } )
+    };
 
-	_fnCallbackFire( settings, "aoStateSaveParams", 'stateSaveParams', [settings, state] );
+    _fnCallbackFire( settings, "aoStateSaveParams", 'stateSaveParams', [settings, state] );
 
-	settings.oSavedState = state;
-	settings.fnStateSaveCallback.call( settings.oInstance, settings, state );
+    settings.oSavedState = state;
+    settings.fnStateSaveCallback.call( settings.oInstance, settings, state );
 }
 
 
@@ -43,96 +44,96 @@ function _fnSaveState ( settings )
  */
 function _fnLoadState ( settings, oInit, callback )
 {
-	var i, ien;
-	var columns = settings.aoColumns;
-	var loaded = function ( s ) {
-		if ( ! s || ! s.time ) {
-			callback();
-			return;
-		}
+    var i, ien;
+    var columns = settings.aoColumns;
+    var loaded = function ( s ) {
+        if ( ! s || ! s.time ) {
+            callback();
+            return;
+        }
 
-		// Allow custom and plug-in manipulation functions to alter the saved data set and
-		// cancelling of loading by returning false
-		var abStateLoad = _fnCallbackFire( settings, 'aoStateLoadParams', 'stateLoadParams', [settings, s] );
-		if ( $.inArray( false, abStateLoad ) !== -1 ) {
-			callback();
-			return;
-		}
+        // Allow custom and plug-in manipulation functions to alter the saved data set and
+        // cancelling of loading by returning false
+        var abStateLoad = _fnCallbackFire( settings, 'aoStateLoadParams', 'stateLoadParams', [settings, s] );
+        if ( $.inArray( false, abStateLoad ) !== -1 ) {
+            callback();
+            return;
+        }
 
-		// Reject old data
-		var duration = settings.iStateDuration;
-		if ( duration > 0 && s.time < +new Date() - (duration*1000) ) {
-			callback();
-			return;
-		}
+        // Reject old data
+        var duration = settings.iStateDuration;
+        if ( duration > 0 && s.time < +new Date() - (duration*1000) ) {
+            callback();
+            return;
+        }
 
-		// Number of columns have changed - all bets are off, no restore of settings
-		if ( s.columns && columns.length !== s.columns.length ) {
-			callback();
-			return;
-		}
+        // Number of columns have changed - all bets are off, no restore of settings
+        if ( s.columns && columns.length !== s.columns.length ) {
+            callback();
+            return;
+        }
 
-		// Store the saved state so it might be accessed at any time
-		settings.oLoadedState = $.extend( true, {}, s );
+        // Store the saved state so it might be accessed at any time
+        settings.oLoadedState = $.extend( true, {}, s );
 
-		// Restore key features - todo - for 1.11 this needs to be done by
-		// subscribed events
-		if ( s.start !== undefined ) {
-			settings._iDisplayStart    = s.start;
-			settings.iInitDisplayStart = s.start;
-		}
-		if ( s.length !== undefined ) {
-			settings._iDisplayLength   = s.length;
-		}
+        // Restore key features - todo - for 1.11 this needs to be done by
+        // subscribed events
+        if ( s.start !== undefined ) {
+            settings._iDisplayStart    = s.start;
+            settings.iInitDisplayStart = s.start;
+        }
+        if ( s.length !== undefined ) {
+            settings._iDisplayLength   = s.length;
+        }
 
-		// Order
-		if ( s.order !== undefined ) {
-			settings.aaSorting = [];
-			$.each( s.order, function ( i, col ) {
-				settings.aaSorting.push( col[0] >= columns.length ?
-					[ 0, col[1] ] :
-					col
-				);
-			} );
-		}
+        // Order
+        if ( s.order !== undefined ) {
+            settings.aaSorting = [];
+            $.each( s.order, function ( i, col ) {
+                settings.aaSorting.push( col[0] >= columns.length ?
+                    [ 0, col[1] ] :
+                    col
+                );
+            } );
+        }
 
-		// Search
-		if ( s.search !== undefined ) {
-			$.extend( settings.oPreviousSearch, _fnSearchToHung( s.search ) );
-		}
+        // Search
+        if ( s.search !== undefined ) {
+            $.extend( settings.oPreviousSearch, _fnSearchToHung( s.search ) );
+        }
 
-		// Columns
-		//
-		if ( s.columns ) {
-			for ( i=0, ien=s.columns.length ; i<ien ; i++ ) {
-				var col = s.columns[i];
+        // Columns
+        //
+        if ( s.columns ) {
+            for ( i=0, ien=s.columns.length ; i<ien ; i++ ) {
+                var col = s.columns[i];
 
-				// Visibility
-				if ( col.visible !== undefined ) {
-					columns[i].bVisible = col.visible;
-				}
+                // Visibility
+                if ( col.visible !== undefined ) {
+                    columns[i].bVisible = col.visible;
+                }
 
-				// Search
-				if ( col.search !== undefined ) {
-					$.extend( settings.aoPreSearchCols[i], _fnSearchToHung( col.search ) );
-				}
-			}
-		}
+                // Search
+                if ( col.search !== undefined ) {
+                    $.extend( settings.aoPreSearchCols[i], _fnSearchToHung( col.search ) );
+                }
+            }
+        }
 
-		_fnCallbackFire( settings, 'aoStateLoaded', 'stateLoaded', [settings, s] );
-		callback();
-	}
+        _fnCallbackFire( settings, 'aoStateLoaded', 'stateLoaded', [settings, s] );
+        callback();
+    }
 
-	if ( ! settings.oFeatures.bStateSave ) {
-		callback();
-		return;
-	}
+    if ( ! settings.oFeatures.bStateSave ) {
+        callback();
+        return;
+    }
 
-	var state = settings.fnStateLoadCallback.call( settings.oInstance, settings, loaded );
+    var state = settings.fnStateLoadCallback.call( settings.oInstance, settings, loaded );
 
-	if ( state !== undefined ) {
-		loaded( state );
-	}
-	// otherwise, wait for the loaded callback to be executed
+    if ( state !== undefined ) {
+        loaded( state );
+    }
+    // otherwise, wait for the loaded callback to be executed
 }
 

--- a/js/model/model.defaults.js
+++ b/js/model/model.defaults.js
@@ -21,20 +21,20 @@
  *  @namespace
  */
 DataTable.defaults = {
-	/**
-	 * An array of data to use for the table, passed in at initialisation which
-	 * will be used in preference to any data which is already in the DOM. This is
-	 * particularly useful for constructing tables purely in Javascript, for
-	 * example with a custom Ajax call.
-	 *  @type array
-	 *  @default null
-	 *
-	 *  @dtopt Option
-	 *  @name DataTable.defaults.data
-	 *
-	 *  @example
-	 *    // Using a 2D array data source
-	 *    $(document).ready( function () {
+    /**
+     * An array of data to use for the table, passed in at initialisation which
+     * will be used in preference to any data which is already in the DOM. This is
+     * particularly useful for constructing tables purely in Javascript, for
+     * example with a custom Ajax call.
+     *  @type array
+     *  @default null
+     *
+     *  @dtopt Option
+     *  @name DataTable.defaults.data
+     *
+     *  @example
+     *    // Using a 2D array data source
+     *    $(document).ready( function () {
 	 *      $('#example').dataTable( {
 	 *        "data": [
 	 *          ['Trident', 'Internet Explorer 4.0', 'Win 95+', 4, 'X'],
@@ -49,10 +49,10 @@ DataTable.defaults = {
 	 *        ]
 	 *      } );
 	 *    } );
-	 *
-	 *  @example
-	 *    // Using an array of objects as a data source (`data`)
-	 *    $(document).ready( function () {
+     *
+     *  @example
+     *    // Using an array of objects as a data source (`data`)
+     *    $(document).ready( function () {
 	 *      $('#example').dataTable( {
 	 *        "data": [
 	 *          {
@@ -79,173 +79,173 @@ DataTable.defaults = {
 	 *        ]
 	 *      } );
 	 *    } );
-	 */
-	"aaData": null,
+     */
+    "aaData": null,
 
 
-	/**
-	 * If ordering is enabled, then DataTables will perform a first pass sort on
-	 * initialisation. You can define which column(s) the sort is performed
-	 * upon, and the sorting direction, with this variable. The `sorting` array
-	 * should contain an array for each column to be sorted initially containing
-	 * the column's index and a direction string ('asc' or 'desc').
-	 *  @type array
-	 *  @default [[0,'asc']]
-	 *
-	 *  @dtopt Option
-	 *  @name DataTable.defaults.order
-	 *
-	 *  @example
-	 *    // Sort by 3rd column first, and then 4th column
-	 *    $(document).ready( function() {
+    /**
+     * If ordering is enabled, then DataTables will perform a first pass sort on
+     * initialisation. You can define which column(s) the sort is performed
+     * upon, and the sorting direction, with this variable. The `sorting` array
+     * should contain an array for each column to be sorted initially containing
+     * the column's index and a direction string ('asc' or 'desc').
+     *  @type array
+     *  @default [[0,'asc']]
+     *
+     *  @dtopt Option
+     *  @name DataTable.defaults.order
+     *
+     *  @example
+     *    // Sort by 3rd column first, and then 4th column
+     *    $(document).ready( function() {
 	 *      $('#example').dataTable( {
 	 *        "order": [[2,'asc'], [3,'desc']]
 	 *      } );
 	 *    } );
-	 *
-	 *    // No initial sorting
-	 *    $(document).ready( function() {
+     *
+     *    // No initial sorting
+     *    $(document).ready( function() {
 	 *      $('#example').dataTable( {
 	 *        "order": []
 	 *      } );
 	 *    } );
-	 */
-	"aaSorting": [[0,'asc']],
+     */
+    "aaSorting": [[0,'asc']],
 
 
-	/**
-	 * This parameter is basically identical to the `sorting` parameter, but
-	 * cannot be overridden by user interaction with the table. What this means
-	 * is that you could have a column (visible or hidden) which the sorting
-	 * will always be forced on first - any sorting after that (from the user)
-	 * will then be performed as required. This can be useful for grouping rows
-	 * together.
-	 *  @type array
-	 *  @default null
-	 *
-	 *  @dtopt Option
-	 *  @name DataTable.defaults.orderFixed
-	 *
-	 *  @example
-	 *    $(document).ready( function() {
+    /**
+     * This parameter is basically identical to the `sorting` parameter, but
+     * cannot be overridden by user interaction with the table. What this means
+     * is that you could have a column (visible or hidden) which the sorting
+     * will always be forced on first - any sorting after that (from the user)
+     * will then be performed as required. This can be useful for grouping rows
+     * together.
+     *  @type array
+     *  @default null
+     *
+     *  @dtopt Option
+     *  @name DataTable.defaults.orderFixed
+     *
+     *  @example
+     *    $(document).ready( function() {
 	 *      $('#example').dataTable( {
 	 *        "orderFixed": [[0,'asc']]
 	 *      } );
 	 *    } )
-	 */
-	"aaSortingFixed": [],
+     */
+    "aaSortingFixed": [],
 
 
-	/**
-	 * DataTables can be instructed to load data to display in the table from a
-	 * Ajax source. This option defines how that Ajax call is made and where to.
-	 *
-	 * The `ajax` property has three different modes of operation, depending on
-	 * how it is defined. These are:
-	 *
-	 * * `string` - Set the URL from where the data should be loaded from.
-	 * * `object` - Define properties for `jQuery.ajax`.
-	 * * `function` - Custom data get function
-	 *
-	 * `string`
-	 * --------
-	 *
-	 * As a string, the `ajax` property simply defines the URL from which
-	 * DataTables will load data.
-	 *
-	 * `object`
-	 * --------
-	 *
-	 * As an object, the parameters in the object are passed to
-	 * [jQuery.ajax](http://api.jquery.com/jQuery.ajax/) allowing fine control
-	 * of the Ajax request. DataTables has a number of default parameters which
-	 * you can override using this option. Please refer to the jQuery
-	 * documentation for a full description of the options available, although
-	 * the following parameters provide additional options in DataTables or
-	 * require special consideration:
-	 *
-	 * * `data` - As with jQuery, `data` can be provided as an object, but it
-	 *   can also be used as a function to manipulate the data DataTables sends
-	 *   to the server. The function takes a single parameter, an object of
-	 *   parameters with the values that DataTables has readied for sending. An
-	 *   object may be returned which will be merged into the DataTables
-	 *   defaults, or you can add the items to the object that was passed in and
-	 *   not return anything from the function. This supersedes `fnServerParams`
-	 *   from DataTables 1.9-.
-	 *
-	 * * `dataSrc` - By default DataTables will look for the property `data` (or
-	 *   `aaData` for compatibility with DataTables 1.9-) when obtaining data
-	 *   from an Ajax source or for server-side processing - this parameter
-	 *   allows that property to be changed. You can use Javascript dotted
-	 *   object notation to get a data source for multiple levels of nesting, or
-	 *   it my be used as a function. As a function it takes a single parameter,
-	 *   the JSON returned from the server, which can be manipulated as
-	 *   required, with the returned value being that used by DataTables as the
-	 *   data source for the table. This supersedes `sAjaxDataProp` from
-	 *   DataTables 1.9-.
-	 *
-	 * * `success` - Should not be overridden it is used internally in
-	 *   DataTables. To manipulate / transform the data returned by the server
-	 *   use `ajax.dataSrc`, or use `ajax` as a function (see below).
-	 *
-	 * `function`
-	 * ----------
-	 *
-	 * As a function, making the Ajax call is left up to yourself allowing
-	 * complete control of the Ajax request. Indeed, if desired, a method other
-	 * than Ajax could be used to obtain the required data, such as Web storage
-	 * or an AIR database.
-	 *
-	 * The function is given four parameters and no return is required. The
-	 * parameters are:
-	 *
-	 * 1. _object_ - Data to send to the server
-	 * 2. _function_ - Callback function that must be executed when the required
-	 *    data has been obtained. That data should be passed into the callback
-	 *    as the only parameter
-	 * 3. _object_ - DataTables settings object for the table
-	 *
-	 * Note that this supersedes `fnServerData` from DataTables 1.9-.
-	 *
-	 *  @type string|object|function
-	 *  @default null
-	 *
-	 *  @dtopt Option
-	 *  @name DataTable.defaults.ajax
-	 *  @since 1.10.0
-	 *
-	 * @example
-	 *   // Get JSON data from a file via Ajax.
-	 *   // Note DataTables expects data in the form `{ data: [ ...data... ] }` by default).
-	 *   $('#example').dataTable( {
+    /**
+     * DataTables can be instructed to load data to display in the table from a
+     * Ajax source. This option defines how that Ajax call is made and where to.
+     *
+     * The `ajax` property has three different modes of operation, depending on
+     * how it is defined. These are:
+     *
+     * * `string` - Set the URL from where the data should be loaded from.
+     * * `object` - Define properties for `jQuery.ajax`.
+     * * `function` - Custom data get function
+     *
+     * `string`
+     * --------
+     *
+     * As a string, the `ajax` property simply defines the URL from which
+     * DataTables will load data.
+     *
+     * `object`
+     * --------
+     *
+     * As an object, the parameters in the object are passed to
+     * [jQuery.ajax](http://api.jquery.com/jQuery.ajax/) allowing fine control
+     * of the Ajax request. DataTables has a number of default parameters which
+     * you can override using this option. Please refer to the jQuery
+     * documentation for a full description of the options available, although
+     * the following parameters provide additional options in DataTables or
+     * require special consideration:
+     *
+     * * `data` - As with jQuery, `data` can be provided as an object, but it
+     *   can also be used as a function to manipulate the data DataTables sends
+     *   to the server. The function takes a single parameter, an object of
+     *   parameters with the values that DataTables has readied for sending. An
+     *   object may be returned which will be merged into the DataTables
+     *   defaults, or you can add the items to the object that was passed in and
+     *   not return anything from the function. This supersedes `fnServerParams`
+     *   from DataTables 1.9-.
+     *
+     * * `dataSrc` - By default DataTables will look for the property `data` (or
+     *   `aaData` for compatibility with DataTables 1.9-) when obtaining data
+     *   from an Ajax source or for server-side processing - this parameter
+     *   allows that property to be changed. You can use Javascript dotted
+     *   object notation to get a data source for multiple levels of nesting, or
+     *   it my be used as a function. As a function it takes a single parameter,
+     *   the JSON returned from the server, which can be manipulated as
+     *   required, with the returned value being that used by DataTables as the
+     *   data source for the table. This supersedes `sAjaxDataProp` from
+     *   DataTables 1.9-.
+     *
+     * * `success` - Should not be overridden it is used internally in
+     *   DataTables. To manipulate / transform the data returned by the server
+     *   use `ajax.dataSrc`, or use `ajax` as a function (see below).
+     *
+     * `function`
+     * ----------
+     *
+     * As a function, making the Ajax call is left up to yourself allowing
+     * complete control of the Ajax request. Indeed, if desired, a method other
+     * than Ajax could be used to obtain the required data, such as Web storage
+     * or an AIR database.
+     *
+     * The function is given four parameters and no return is required. The
+     * parameters are:
+     *
+     * 1. _object_ - Data to send to the server
+     * 2. _function_ - Callback function that must be executed when the required
+     *    data has been obtained. That data should be passed into the callback
+     *    as the only parameter
+     * 3. _object_ - DataTables settings object for the table
+     *
+     * Note that this supersedes `fnServerData` from DataTables 1.9-.
+     *
+     *  @type string|object|function
+     *  @default null
+     *
+     *  @dtopt Option
+     *  @name DataTable.defaults.ajax
+     *  @since 1.10.0
+     *
+     * @example
+     *   // Get JSON data from a file via Ajax.
+     *   // Note DataTables expects data in the form `{ data: [ ...data... ] }` by default).
+     *   $('#example').dataTable( {
 	 *     "ajax": "data.json"
 	 *   } );
-	 *
-	 * @example
-	 *   // Get JSON data from a file via Ajax, using `dataSrc` to change
-	 *   // `data` to `tableData` (i.e. `{ tableData: [ ...data... ] }`)
-	 *   $('#example').dataTable( {
+     *
+     * @example
+     *   // Get JSON data from a file via Ajax, using `dataSrc` to change
+     *   // `data` to `tableData` (i.e. `{ tableData: [ ...data... ] }`)
+     *   $('#example').dataTable( {
 	 *     "ajax": {
 	 *       "url": "data.json",
 	 *       "dataSrc": "tableData"
 	 *     }
 	 *   } );
-	 *
-	 * @example
-	 *   // Get JSON data from a file via Ajax, using `dataSrc` to read data
-	 *   // from a plain array rather than an array in an object
-	 *   $('#example').dataTable( {
+     *
+     * @example
+     *   // Get JSON data from a file via Ajax, using `dataSrc` to read data
+     *   // from a plain array rather than an array in an object
+     *   $('#example').dataTable( {
 	 *     "ajax": {
 	 *       "url": "data.json",
 	 *       "dataSrc": ""
 	 *     }
 	 *   } );
-	 *
-	 * @example
-	 *   // Manipulate the data returned from the server - add a link to data
-	 *   // (note this can, should, be done using `render` for the column - this
-	 *   // is just a simple example of how the data can be manipulated).
-	 *   $('#example').dataTable( {
+     *
+     * @example
+     *   // Manipulate the data returned from the server - add a link to data
+     *   // (note this can, should, be done using `render` for the column - this
+     *   // is just a simple example of how the data can be manipulated).
+     *   $('#example').dataTable( {
 	 *     "ajax": {
 	 *       "url": "data.json",
 	 *       "dataSrc": function ( json ) {
@@ -256,10 +256,10 @@ DataTable.defaults = {
 	 *       }
 	 *     }
 	 *   } );
-	 *
-	 * @example
-	 *   // Add data to the request
-	 *   $('#example').dataTable( {
+     *
+     * @example
+     *   // Add data to the request
+     *   $('#example').dataTable( {
 	 *     "ajax": {
 	 *       "url": "data.json",
 	 *       "data": function ( d ) {
@@ -269,106 +269,106 @@ DataTable.defaults = {
 	 *       }
 	 *     }
 	 *   } );
-	 *
-	 * @example
-	 *   // Send request as POST
-	 *   $('#example').dataTable( {
+     *
+     * @example
+     *   // Send request as POST
+     *   $('#example').dataTable( {
 	 *     "ajax": {
 	 *       "url": "data.json",
 	 *       "type": "POST"
 	 *     }
 	 *   } );
-	 *
-	 * @example
-	 *   // Get the data from localStorage (could interface with a form for
-	 *   // adding, editing and removing rows).
-	 *   $('#example').dataTable( {
+     *
+     * @example
+     *   // Get the data from localStorage (could interface with a form for
+     *   // adding, editing and removing rows).
+     *   $('#example').dataTable( {
 	 *     "ajax": function (data, callback, settings) {
 	 *       callback(
 	 *         JSON.parse( localStorage.getItem('dataTablesData') )
 	 *       );
 	 *     }
 	 *   } );
-	 */
-	"ajax": null,
+     */
+    "ajax": null,
 
 
-	/**
-	 * This parameter allows you to readily specify the entries in the length drop
-	 * down menu that DataTables shows when pagination is enabled. It can be
-	 * either a 1D array of options which will be used for both the displayed
-	 * option and the value, or a 2D array which will use the array in the first
-	 * position as the value, and the array in the second position as the
-	 * displayed options (useful for language strings such as 'All').
-	 *
-	 * Note that the `pageLength` property will be automatically set to the
-	 * first value given in this array, unless `pageLength` is also provided.
-	 *  @type array
-	 *  @default [ 10, 25, 50, 100 ]
-	 *
-	 *  @dtopt Option
-	 *  @name DataTable.defaults.lengthMenu
-	 *
-	 *  @example
-	 *    $(document).ready( function() {
+    /**
+     * This parameter allows you to readily specify the entries in the length drop
+     * down menu that DataTables shows when pagination is enabled. It can be
+     * either a 1D array of options which will be used for both the displayed
+     * option and the value, or a 2D array which will use the array in the first
+     * position as the value, and the array in the second position as the
+     * displayed options (useful for language strings such as 'All').
+     *
+     * Note that the `pageLength` property will be automatically set to the
+     * first value given in this array, unless `pageLength` is also provided.
+     *  @type array
+     *  @default [ 10, 25, 50, 100 ]
+     *
+     *  @dtopt Option
+     *  @name DataTable.defaults.lengthMenu
+     *
+     *  @example
+     *    $(document).ready( function() {
 	 *      $('#example').dataTable( {
 	 *        "lengthMenu": [[10, 25, 50, -1], [10, 25, 50, "All"]]
 	 *      } );
 	 *    } );
-	 */
-	"aLengthMenu": [ 10, 25, 50, 100 ],
+     */
+    "aLengthMenu": [ 10, 25, 50, 100 ],
 
 
-	/**
-	 * The `columns` option in the initialisation parameter allows you to define
-	 * details about the way individual columns behave. For a full list of
-	 * column options that can be set, please see
-	 * {@link DataTable.defaults.column}. Note that if you use `columns` to
-	 * define your columns, you must have an entry in the array for every single
-	 * column that you have in your table (these can be null if you don't which
-	 * to specify any options).
-	 *  @member
-	 *
-	 *  @name DataTable.defaults.column
-	 */
-	"aoColumns": null,
+    /**
+     * The `columns` option in the initialisation parameter allows you to define
+     * details about the way individual columns behave. For a full list of
+     * column options that can be set, please see
+     * {@link DataTable.defaults.column}. Note that if you use `columns` to
+     * define your columns, you must have an entry in the array for every single
+     * column that you have in your table (these can be null if you don't which
+     * to specify any options).
+     *  @member
+     *
+     *  @name DataTable.defaults.column
+     */
+    "aoColumns": null,
 
-	/**
-	 * Very similar to `columns`, `columnDefs` allows you to target a specific
-	 * column, multiple columns, or all columns, using the `targets` property of
-	 * each object in the array. This allows great flexibility when creating
-	 * tables, as the `columnDefs` arrays can be of any length, targeting the
-	 * columns you specifically want. `columnDefs` may use any of the column
-	 * options available: {@link DataTable.defaults.column}, but it _must_
-	 * have `targets` defined in each object in the array. Values in the `targets`
-	 * array may be:
-	 *   <ul>
-	 *     <li>a string - class name will be matched on the TH for the column</li>
-	 *     <li>0 or a positive integer - column index counting from the left</li>
-	 *     <li>a negative integer - column index counting from the right</li>
-	 *     <li>the string "_all" - all columns (i.e. assign a default)</li>
-	 *   </ul>
-	 *  @member
-	 *
-	 *  @name DataTable.defaults.columnDefs
-	 */
-	"aoColumnDefs": null,
+    /**
+     * Very similar to `columns`, `columnDefs` allows you to target a specific
+     * column, multiple columns, or all columns, using the `targets` property of
+     * each object in the array. This allows great flexibility when creating
+     * tables, as the `columnDefs` arrays can be of any length, targeting the
+     * columns you specifically want. `columnDefs` may use any of the column
+     * options available: {@link DataTable.defaults.column}, but it _must_
+     * have `targets` defined in each object in the array. Values in the `targets`
+     * array may be:
+     *   <ul>
+     *     <li>a string - class name will be matched on the TH for the column</li>
+     *     <li>0 or a positive integer - column index counting from the left</li>
+     *     <li>a negative integer - column index counting from the right</li>
+     *     <li>the string "_all" - all columns (i.e. assign a default)</li>
+     *   </ul>
+     *  @member
+     *
+     *  @name DataTable.defaults.columnDefs
+     */
+    "aoColumnDefs": null,
 
 
-	/**
-	 * Basically the same as `search`, this parameter defines the individual column
-	 * filtering state at initialisation time. The array must be of the same size
-	 * as the number of columns, and each element be an object with the parameters
-	 * `search` and `escapeRegex` (the latter is optional). 'null' is also
-	 * accepted and the default will be used.
-	 *  @type array
-	 *  @default []
-	 *
-	 *  @dtopt Option
-	 *  @name DataTable.defaults.searchCols
-	 *
-	 *  @example
-	 *    $(document).ready( function() {
+    /**
+     * Basically the same as `search`, this parameter defines the individual column
+     * filtering state at initialisation time. The array must be of the same size
+     * as the number of columns, and each element be an object with the parameters
+     * `search` and `escapeRegex` (the latter is optional). 'null' is also
+     * accepted and the default will be used.
+     *  @type array
+     *  @default []
+     *
+     *  @dtopt Option
+     *  @name DataTable.defaults.searchCols
+     *
+     *  @example
+     *    $(document).ready( function() {
 	 *      $('#example').dataTable( {
 	 *        "searchCols": [
 	 *          null,
@@ -378,87 +378,87 @@ DataTable.defaults = {
 	 *        ]
 	 *      } );
 	 *    } )
-	 */
-	"aoSearchCols": [],
+     */
+    "aoSearchCols": [],
 
 
-	/**
-	 * An array of CSS classes that should be applied to displayed rows. This
-	 * array may be of any length, and DataTables will apply each class
-	 * sequentially, looping when required.
-	 *  @type array
-	 *  @default null <i>Will take the values determined by the `oClasses.stripe*`
-	 *    options</i>
-	 *
-	 *  @dtopt Option
-	 *  @name DataTable.defaults.stripeClasses
-	 *
-	 *  @example
-	 *    $(document).ready( function() {
+    /**
+     * An array of CSS classes that should be applied to displayed rows. This
+     * array may be of any length, and DataTables will apply each class
+     * sequentially, looping when required.
+     *  @type array
+     *  @default null <i>Will take the values determined by the `oClasses.stripe*`
+     *    options</i>
+     *
+     *  @dtopt Option
+     *  @name DataTable.defaults.stripeClasses
+     *
+     *  @example
+     *    $(document).ready( function() {
 	 *      $('#example').dataTable( {
 	 *        "stripeClasses": [ 'strip1', 'strip2', 'strip3' ]
 	 *      } );
 	 *    } )
-	 */
-	"asStripeClasses": null,
+     */
+    "asStripeClasses": null,
 
 
-	/**
-	 * Enable or disable automatic column width calculation. This can be disabled
-	 * as an optimisation (it takes some time to calculate the widths) if the
-	 * tables widths are passed in using `columns`.
-	 *  @type boolean
-	 *  @default true
-	 *
-	 *  @dtopt Features
-	 *  @name DataTable.defaults.autoWidth
-	 *
-	 *  @example
-	 *    $(document).ready( function () {
+    /**
+     * Enable or disable automatic column width calculation. This can be disabled
+     * as an optimisation (it takes some time to calculate the widths) if the
+     * tables widths are passed in using `columns`.
+     *  @type boolean
+     *  @default true
+     *
+     *  @dtopt Features
+     *  @name DataTable.defaults.autoWidth
+     *
+     *  @example
+     *    $(document).ready( function () {
 	 *      $('#example').dataTable( {
 	 *        "autoWidth": false
 	 *      } );
 	 *    } );
-	 */
-	"bAutoWidth": true,
+     */
+    "bAutoWidth": true,
 
 
-	/**
-	 * Deferred rendering can provide DataTables with a huge speed boost when you
-	 * are using an Ajax or JS data source for the table. This option, when set to
-	 * true, will cause DataTables to defer the creation of the table elements for
-	 * each row until they are needed for a draw - saving a significant amount of
-	 * time.
-	 *  @type boolean
-	 *  @default false
-	 *
-	 *  @dtopt Features
-	 *  @name DataTable.defaults.deferRender
-	 *
-	 *  @example
-	 *    $(document).ready( function() {
+    /**
+     * Deferred rendering can provide DataTables with a huge speed boost when you
+     * are using an Ajax or JS data source for the table. This option, when set to
+     * true, will cause DataTables to defer the creation of the table elements for
+     * each row until they are needed for a draw - saving a significant amount of
+     * time.
+     *  @type boolean
+     *  @default false
+     *
+     *  @dtopt Features
+     *  @name DataTable.defaults.deferRender
+     *
+     *  @example
+     *    $(document).ready( function() {
 	 *      $('#example').dataTable( {
 	 *        "ajax": "sources/arrays.txt",
 	 *        "deferRender": true
 	 *      } );
 	 *    } );
-	 */
-	"bDeferRender": false,
+     */
+    "bDeferRender": false,
 
 
-	/**
-	 * Replace a DataTable which matches the given selector and replace it with
-	 * one which has the properties of the new initialisation object passed. If no
-	 * table matches the selector, then the new DataTable will be constructed as
-	 * per normal.
-	 *  @type boolean
-	 *  @default false
-	 *
-	 *  @dtopt Options
-	 *  @name DataTable.defaults.destroy
-	 *
-	 *  @example
-	 *    $(document).ready( function() {
+    /**
+     * Replace a DataTable which matches the given selector and replace it with
+     * one which has the properties of the new initialisation object passed. If no
+     * table matches the selector, then the new DataTable will be constructed as
+     * per normal.
+     *  @type boolean
+     *  @default false
+     *
+     *  @dtopt Options
+     *  @name DataTable.defaults.destroy
+     *
+     *  @example
+     *    $(document).ready( function() {
 	 *      $('#example').dataTable( {
 	 *        "srollY": "200px",
 	 *        "paginate": false
@@ -470,336 +470,336 @@ DataTable.defaults = {
 	 *        "destroy": true
 	 *      } );
 	 *    } );
-	 */
-	"bDestroy": false,
+     */
+    "bDestroy": false,
 
 
-	/**
-	 * Enable or disable filtering of data. Filtering in DataTables is "smart" in
-	 * that it allows the end user to input multiple words (space separated) and
-	 * will match a row containing those words, even if not in the order that was
-	 * specified (this allow matching across multiple columns). Note that if you
-	 * wish to use filtering in DataTables this must remain 'true' - to remove the
-	 * default filtering input box and retain filtering abilities, please use
-	 * {@link DataTable.defaults.dom}.
-	 *  @type boolean
-	 *  @default true
-	 *
-	 *  @dtopt Features
-	 *  @name DataTable.defaults.searching
-	 *
-	 *  @example
-	 *    $(document).ready( function () {
+    /**
+     * Enable or disable filtering of data. Filtering in DataTables is "smart" in
+     * that it allows the end user to input multiple words (space separated) and
+     * will match a row containing those words, even if not in the order that was
+     * specified (this allow matching across multiple columns). Note that if you
+     * wish to use filtering in DataTables this must remain 'true' - to remove the
+     * default filtering input box and retain filtering abilities, please use
+     * {@link DataTable.defaults.dom}.
+     *  @type boolean
+     *  @default true
+     *
+     *  @dtopt Features
+     *  @name DataTable.defaults.searching
+     *
+     *  @example
+     *    $(document).ready( function () {
 	 *      $('#example').dataTable( {
 	 *        "searching": false
 	 *      } );
 	 *    } );
-	 */
-	"bFilter": true,
+     */
+    "bFilter": true,
 
 
-	/**
-	 * Enable or disable the table information display. This shows information
-	 * about the data that is currently visible on the page, including information
-	 * about filtered data if that action is being performed.
-	 *  @type boolean
-	 *  @default true
-	 *
-	 *  @dtopt Features
-	 *  @name DataTable.defaults.info
-	 *
-	 *  @example
-	 *    $(document).ready( function () {
+    /**
+     * Enable or disable the table information display. This shows information
+     * about the data that is currently visible on the page, including information
+     * about filtered data if that action is being performed.
+     *  @type boolean
+     *  @default true
+     *
+     *  @dtopt Features
+     *  @name DataTable.defaults.info
+     *
+     *  @example
+     *    $(document).ready( function () {
 	 *      $('#example').dataTable( {
 	 *        "info": false
 	 *      } );
 	 *    } );
-	 */
-	"bInfo": true,
+     */
+    "bInfo": true,
 
 
-	/**
-	 * Enable jQuery UI ThemeRoller support (required as ThemeRoller requires some
-	 * slightly different and additional mark-up from what DataTables has
-	 * traditionally used).
-	 *  @type boolean
-	 *  @default false
-	 *
-	 *  @dtopt Features
-	 *  @name DataTable.defaults.jQueryUI
-	 *
-	 *  @example
-	 *    $(document).ready( function() {
+    /**
+     * Enable jQuery UI ThemeRoller support (required as ThemeRoller requires some
+     * slightly different and additional mark-up from what DataTables has
+     * traditionally used).
+     *  @type boolean
+     *  @default false
+     *
+     *  @dtopt Features
+     *  @name DataTable.defaults.jQueryUI
+     *
+     *  @example
+     *    $(document).ready( function() {
 	 *      $('#example').dataTable( {
 	 *        "jQueryUI": true
 	 *      } );
 	 *    } );
-	 */
-	"bJQueryUI": false,
+     */
+    "bJQueryUI": false,
 
 
-	/**
-	 * Allows the end user to select the size of a formatted page from a select
-	 * menu (sizes are 10, 25, 50 and 100). Requires pagination (`paginate`).
-	 *  @type boolean
-	 *  @default true
-	 *
-	 *  @dtopt Features
-	 *  @name DataTable.defaults.lengthChange
-	 *
-	 *  @example
-	 *    $(document).ready( function () {
+    /**
+     * Allows the end user to select the size of a formatted page from a select
+     * menu (sizes are 10, 25, 50 and 100). Requires pagination (`paginate`).
+     *  @type boolean
+     *  @default true
+     *
+     *  @dtopt Features
+     *  @name DataTable.defaults.lengthChange
+     *
+     *  @example
+     *    $(document).ready( function () {
 	 *      $('#example').dataTable( {
 	 *        "lengthChange": false
 	 *      } );
 	 *    } );
-	 */
-	"bLengthChange": true,
+     */
+    "bLengthChange": true,
 
 
-	/**
-	 * Enable or disable pagination.
-	 *  @type boolean
-	 *  @default true
-	 *
-	 *  @dtopt Features
-	 *  @name DataTable.defaults.paging
-	 *
-	 *  @example
-	 *    $(document).ready( function () {
+    /**
+     * Enable or disable pagination.
+     *  @type boolean
+     *  @default true
+     *
+     *  @dtopt Features
+     *  @name DataTable.defaults.paging
+     *
+     *  @example
+     *    $(document).ready( function () {
 	 *      $('#example').dataTable( {
 	 *        "paging": false
 	 *      } );
 	 *    } );
-	 */
-	"bPaginate": true,
+     */
+    "bPaginate": true,
 
 
-	/**
-	 * Enable or disable the display of a 'processing' indicator when the table is
-	 * being processed (e.g. a sort). This is particularly useful for tables with
-	 * large amounts of data where it can take a noticeable amount of time to sort
-	 * the entries.
-	 *  @type boolean
-	 *  @default false
-	 *
-	 *  @dtopt Features
-	 *  @name DataTable.defaults.processing
-	 *
-	 *  @example
-	 *    $(document).ready( function () {
+    /**
+     * Enable or disable the display of a 'processing' indicator when the table is
+     * being processed (e.g. a sort). This is particularly useful for tables with
+     * large amounts of data where it can take a noticeable amount of time to sort
+     * the entries.
+     *  @type boolean
+     *  @default false
+     *
+     *  @dtopt Features
+     *  @name DataTable.defaults.processing
+     *
+     *  @example
+     *    $(document).ready( function () {
 	 *      $('#example').dataTable( {
 	 *        "processing": true
 	 *      } );
 	 *    } );
-	 */
-	"bProcessing": false,
+     */
+    "bProcessing": false,
 
 
-	/**
-	 * Retrieve the DataTables object for the given selector. Note that if the
-	 * table has already been initialised, this parameter will cause DataTables
-	 * to simply return the object that has already been set up - it will not take
-	 * account of any changes you might have made to the initialisation object
-	 * passed to DataTables (setting this parameter to true is an acknowledgement
-	 * that you understand this). `destroy` can be used to reinitialise a table if
-	 * you need.
-	 *  @type boolean
-	 *  @default false
-	 *
-	 *  @dtopt Options
-	 *  @name DataTable.defaults.retrieve
-	 *
-	 *  @example
-	 *    $(document).ready( function() {
+    /**
+     * Retrieve the DataTables object for the given selector. Note that if the
+     * table has already been initialised, this parameter will cause DataTables
+     * to simply return the object that has already been set up - it will not take
+     * account of any changes you might have made to the initialisation object
+     * passed to DataTables (setting this parameter to true is an acknowledgement
+     * that you understand this). `destroy` can be used to reinitialise a table if
+     * you need.
+     *  @type boolean
+     *  @default false
+     *
+     *  @dtopt Options
+     *  @name DataTable.defaults.retrieve
+     *
+     *  @example
+     *    $(document).ready( function() {
 	 *      initTable();
 	 *      tableActions();
 	 *    } );
-	 *
-	 *    function initTable ()
-	 *    {
+     *
+     *    function initTable ()
+     *    {
 	 *      return $('#example').dataTable( {
 	 *        "scrollY": "200px",
 	 *        "paginate": false,
 	 *        "retrieve": true
 	 *      } );
 	 *    }
-	 *
-	 *    function tableActions ()
-	 *    {
+     *
+     *    function tableActions ()
+     *    {
 	 *      var table = initTable();
 	 *      // perform API operations with oTable
 	 *    }
-	 */
-	"bRetrieve": false,
+     */
+    "bRetrieve": false,
 
 
-	/**
-	 * When vertical (y) scrolling is enabled, DataTables will force the height of
-	 * the table's viewport to the given height at all times (useful for layout).
-	 * However, this can look odd when filtering data down to a small data set,
-	 * and the footer is left "floating" further down. This parameter (when
-	 * enabled) will cause DataTables to collapse the table's viewport down when
-	 * the result set will fit within the given Y height.
-	 *  @type boolean
-	 *  @default false
-	 *
-	 *  @dtopt Options
-	 *  @name DataTable.defaults.scrollCollapse
-	 *
-	 *  @example
-	 *    $(document).ready( function() {
+    /**
+     * When vertical (y) scrolling is enabled, DataTables will force the height of
+     * the table's viewport to the given height at all times (useful for layout).
+     * However, this can look odd when filtering data down to a small data set,
+     * and the footer is left "floating" further down. This parameter (when
+     * enabled) will cause DataTables to collapse the table's viewport down when
+     * the result set will fit within the given Y height.
+     *  @type boolean
+     *  @default false
+     *
+     *  @dtopt Options
+     *  @name DataTable.defaults.scrollCollapse
+     *
+     *  @example
+     *    $(document).ready( function() {
 	 *      $('#example').dataTable( {
 	 *        "scrollY": "200",
 	 *        "scrollCollapse": true
 	 *      } );
 	 *    } );
-	 */
-	"bScrollCollapse": false,
+     */
+    "bScrollCollapse": false,
 
 
-	/**
-	 * Configure DataTables to use server-side processing. Note that the
-	 * `ajax` parameter must also be given in order to give DataTables a
-	 * source to obtain the required data for each draw.
-	 *  @type boolean
-	 *  @default false
-	 *
-	 *  @dtopt Features
-	 *  @dtopt Server-side
-	 *  @name DataTable.defaults.serverSide
-	 *
-	 *  @example
-	 *    $(document).ready( function () {
+    /**
+     * Configure DataTables to use server-side processing. Note that the
+     * `ajax` parameter must also be given in order to give DataTables a
+     * source to obtain the required data for each draw.
+     *  @type boolean
+     *  @default false
+     *
+     *  @dtopt Features
+     *  @dtopt Server-side
+     *  @name DataTable.defaults.serverSide
+     *
+     *  @example
+     *    $(document).ready( function () {
 	 *      $('#example').dataTable( {
 	 *        "serverSide": true,
 	 *        "ajax": "xhr.php"
 	 *      } );
 	 *    } );
-	 */
-	"bServerSide": false,
+     */
+    "bServerSide": false,
 
 
-	/**
-	 * Enable or disable sorting of columns. Sorting of individual columns can be
-	 * disabled by the `sortable` option for each column.
-	 *  @type boolean
-	 *  @default true
-	 *
-	 *  @dtopt Features
-	 *  @name DataTable.defaults.ordering
-	 *
-	 *  @example
-	 *    $(document).ready( function () {
+    /**
+     * Enable or disable sorting of columns. Sorting of individual columns can be
+     * disabled by the `sortable` option for each column.
+     *  @type boolean
+     *  @default true
+     *
+     *  @dtopt Features
+     *  @name DataTable.defaults.ordering
+     *
+     *  @example
+     *    $(document).ready( function () {
 	 *      $('#example').dataTable( {
 	 *        "ordering": false
 	 *      } );
 	 *    } );
-	 */
-	"bSort": true,
+     */
+    "bSort": true,
 
 
-	/**
-	 * Enable or display DataTables' ability to sort multiple columns at the
-	 * same time (activated by shift-click by the user).
-	 *  @type boolean
-	 *  @default true
-	 *
-	 *  @dtopt Options
-	 *  @name DataTable.defaults.orderMulti
-	 *
-	 *  @example
-	 *    // Disable multiple column sorting ability
-	 *    $(document).ready( function () {
+    /**
+     * Enable or display DataTables' ability to sort multiple columns at the
+     * same time (activated by shift-click by the user).
+     *  @type boolean
+     *  @default true
+     *
+     *  @dtopt Options
+     *  @name DataTable.defaults.orderMulti
+     *
+     *  @example
+     *    // Disable multiple column sorting ability
+     *    $(document).ready( function () {
 	 *      $('#example').dataTable( {
 	 *        "orderMulti": false
 	 *      } );
 	 *    } );
-	 */
-	"bSortMulti": true,
+     */
+    "bSortMulti": true,
 
 
-	/**
-	 * Allows control over whether DataTables should use the top (true) unique
-	 * cell that is found for a single column, or the bottom (false - default).
-	 * This is useful when using complex headers.
-	 *  @type boolean
-	 *  @default false
-	 *
-	 *  @dtopt Options
-	 *  @name DataTable.defaults.orderCellsTop
-	 *
-	 *  @example
-	 *    $(document).ready( function() {
+    /**
+     * Allows control over whether DataTables should use the top (true) unique
+     * cell that is found for a single column, or the bottom (false - default).
+     * This is useful when using complex headers.
+     *  @type boolean
+     *  @default false
+     *
+     *  @dtopt Options
+     *  @name DataTable.defaults.orderCellsTop
+     *
+     *  @example
+     *    $(document).ready( function() {
 	 *      $('#example').dataTable( {
 	 *        "orderCellsTop": true
 	 *      } );
 	 *    } );
-	 */
-	"bSortCellsTop": false,
+     */
+    "bSortCellsTop": false,
 
 
-	/**
-	 * Enable or disable the addition of the classes `sorting\_1`, `sorting\_2` and
-	 * `sorting\_3` to the columns which are currently being sorted on. This is
-	 * presented as a feature switch as it can increase processing time (while
-	 * classes are removed and added) so for large data sets you might want to
-	 * turn this off.
-	 *  @type boolean
-	 *  @default true
-	 *
-	 *  @dtopt Features
-	 *  @name DataTable.defaults.orderClasses
-	 *
-	 *  @example
-	 *    $(document).ready( function () {
+    /**
+     * Enable or disable the addition of the classes `sorting\_1`, `sorting\_2` and
+     * `sorting\_3` to the columns which are currently being sorted on. This is
+     * presented as a feature switch as it can increase processing time (while
+     * classes are removed and added) so for large data sets you might want to
+     * turn this off.
+     *  @type boolean
+     *  @default true
+     *
+     *  @dtopt Features
+     *  @name DataTable.defaults.orderClasses
+     *
+     *  @example
+     *    $(document).ready( function () {
 	 *      $('#example').dataTable( {
 	 *        "orderClasses": false
 	 *      } );
 	 *    } );
-	 */
-	"bSortClasses": true,
+     */
+    "bSortClasses": true,
 
 
-	/**
-	 * Enable or disable state saving. When enabled HTML5 `localStorage` will be
-	 * used to save table display information such as pagination information,
-	 * display length, filtering and sorting. As such when the end user reloads
-	 * the page the display display will match what thy had previously set up.
-	 *
-	 * Due to the use of `localStorage` the default state saving is not supported
-	 * in IE6 or 7. If state saving is required in those browsers, use
-	 * `stateSaveCallback` to provide a storage solution such as cookies.
-	 *  @type boolean
-	 *  @default false
-	 *
-	 *  @dtopt Features
-	 *  @name DataTable.defaults.stateSave
-	 *
-	 *  @example
-	 *    $(document).ready( function () {
+    /**
+     * Enable or disable state saving. When enabled HTML5 `localStorage` will be
+     * used to save table display information such as pagination information,
+     * display length, filtering and sorting. As such when the end user reloads
+     * the page the display display will match what thy had previously set up.
+     *
+     * Due to the use of `localStorage` the default state saving is not supported
+     * in IE6 or 7. If state saving is required in those browsers, use
+     * `stateSaveCallback` to provide a storage solution such as cookies.
+     *  @type boolean
+     *  @default false
+     *
+     *  @dtopt Features
+     *  @name DataTable.defaults.stateSave
+     *
+     *  @example
+     *    $(document).ready( function () {
 	 *      $('#example').dataTable( {
 	 *        "stateSave": true
 	 *      } );
 	 *    } );
-	 */
-	"bStateSave": false,
+     */
+    "bStateSave": false,
 
 
-	/**
-	 * This function is called when a TR element is created (and all TD child
-	 * elements have been inserted), or registered if using a DOM source, allowing
-	 * manipulation of the TR element (adding classes etc).
-	 *  @type function
-	 *  @param {node} row "TR" element for the current row
-	 *  @param {array} data Raw data array for this row
-	 *  @param {int} dataIndex The index of this row in the internal aoData array
-	 *
-	 *  @dtopt Callbacks
-	 *  @name DataTable.defaults.createdRow
-	 *
-	 *  @example
-	 *    $(document).ready( function() {
+    /**
+     * This function is called when a TR element is created (and all TD child
+     * elements have been inserted), or registered if using a DOM source, allowing
+     * manipulation of the TR element (adding classes etc).
+     *  @type function
+     *  @param {node} row "TR" element for the current row
+     *  @param {array} data Raw data array for this row
+     *  @param {int} dataIndex The index of this row in the internal aoData array
+     *
+     *  @dtopt Callbacks
+     *  @name DataTable.defaults.createdRow
+     *
+     *  @example
+     *    $(document).ready( function() {
 	 *      $('#example').dataTable( {
 	 *        "createdRow": function( row, data, dataIndex ) {
 	 *          // Bold the grade for all 'A' grade browsers
@@ -810,77 +810,77 @@ DataTable.defaults = {
 	 *        }
 	 *      } );
 	 *    } );
-	 */
-	"fnCreatedRow": null,
+     */
+    "fnCreatedRow": null,
 
 
-	/**
-	 * This function is called on every 'draw' event, and allows you to
-	 * dynamically modify any aspect you want about the created DOM.
-	 *  @type function
-	 *  @param {object} settings DataTables settings object
-	 *
-	 *  @dtopt Callbacks
-	 *  @name DataTable.defaults.drawCallback
-	 *
-	 *  @example
-	 *    $(document).ready( function() {
+    /**
+     * This function is called on every 'draw' event, and allows you to
+     * dynamically modify any aspect you want about the created DOM.
+     *  @type function
+     *  @param {object} settings DataTables settings object
+     *
+     *  @dtopt Callbacks
+     *  @name DataTable.defaults.drawCallback
+     *
+     *  @example
+     *    $(document).ready( function() {
 	 *      $('#example').dataTable( {
 	 *        "drawCallback": function( settings ) {
 	 *          alert( 'DataTables has redrawn the table' );
 	 *        }
 	 *      } );
 	 *    } );
-	 */
-	"fnDrawCallback": null,
+     */
+    "fnDrawCallback": null,
 
 
-	/**
-	 * Identical to fnHeaderCallback() but for the table footer this function
-	 * allows you to modify the table footer on every 'draw' event.
-	 *  @type function
-	 *  @param {node} foot "TR" element for the footer
-	 *  @param {array} data Full table data (as derived from the original HTML)
-	 *  @param {int} start Index for the current display starting point in the
-	 *    display array
-	 *  @param {int} end Index for the current display ending point in the
-	 *    display array
-	 *  @param {array int} display Index array to translate the visual position
-	 *    to the full data array
-	 *
-	 *  @dtopt Callbacks
-	 *  @name DataTable.defaults.footerCallback
-	 *
-	 *  @example
-	 *    $(document).ready( function() {
+    /**
+     * Identical to fnHeaderCallback() but for the table footer this function
+     * allows you to modify the table footer on every 'draw' event.
+     *  @type function
+     *  @param {node} foot "TR" element for the footer
+     *  @param {array} data Full table data (as derived from the original HTML)
+     *  @param {int} start Index for the current display starting point in the
+     *    display array
+     *  @param {int} end Index for the current display ending point in the
+     *    display array
+     *  @param {array int} display Index array to translate the visual position
+     *    to the full data array
+     *
+     *  @dtopt Callbacks
+     *  @name DataTable.defaults.footerCallback
+     *
+     *  @example
+     *    $(document).ready( function() {
 	 *      $('#example').dataTable( {
 	 *        "footerCallback": function( tfoot, data, start, end, display ) {
 	 *          tfoot.getElementsByTagName('th')[0].innerHTML = "Starting index is "+start;
 	 *        }
 	 *      } );
 	 *    } )
-	 */
-	"fnFooterCallback": null,
+     */
+    "fnFooterCallback": null,
 
 
-	/**
-	 * When rendering large numbers in the information element for the table
-	 * (i.e. "Showing 1 to 10 of 57 entries") DataTables will render large numbers
-	 * to have a comma separator for the 'thousands' units (e.g. 1 million is
-	 * rendered as "1,000,000") to help readability for the end user. This
-	 * function will override the default method DataTables uses.
-	 *  @type function
-	 *  @member
-	 *  @param {int} toFormat number to be formatted
-	 *  @returns {string} formatted string for DataTables to show the number
-	 *
-	 *  @dtopt Callbacks
-	 *  @name DataTable.defaults.formatNumber
-	 *
-	 *  @example
-	 *    // Format a number using a single quote for the separator (note that
-	 *    // this can also be done with the language.thousands option)
-	 *    $(document).ready( function() {
+    /**
+     * When rendering large numbers in the information element for the table
+     * (i.e. "Showing 1 to 10 of 57 entries") DataTables will render large numbers
+     * to have a comma separator for the 'thousands' units (e.g. 1 million is
+     * rendered as "1,000,000") to help readability for the end user. This
+     * function will override the default method DataTables uses.
+     *  @type function
+     *  @member
+     *  @param {int} toFormat number to be formatted
+     *  @returns {string} formatted string for DataTables to show the number
+     *
+     *  @dtopt Callbacks
+     *  @name DataTable.defaults.formatNumber
+     *
+     *  @example
+     *    // Format a number using a single quote for the separator (note that
+     *    // this can also be done with the language.thousands option)
+     *    $(document).ready( function() {
 	 *      $('#example').dataTable( {
 	 *        "formatNumber": function ( toFormat ) {
 	 *          return toFormat.toString().replace(
@@ -889,113 +889,113 @@ DataTable.defaults = {
 	 *        };
 	 *      } );
 	 *    } );
-	 */
-	"fnFormatNumber": function ( toFormat ) {
-		return toFormat.toString().replace(
-			/\B(?=(\d{3})+(?!\d))/g,
-			this.oLanguage.sThousands
-		);
-	},
+     */
+    "fnFormatNumber": function ( toFormat ) {
+        return toFormat.toString().replace(
+            /\B(?=(\d{3})+(?!\d))/g,
+            this.oLanguage.sThousands
+        );
+    },
 
 
-	/**
-	 * This function is called on every 'draw' event, and allows you to
-	 * dynamically modify the header row. This can be used to calculate and
-	 * display useful information about the table.
-	 *  @type function
-	 *  @param {node} head "TR" element for the header
-	 *  @param {array} data Full table data (as derived from the original HTML)
-	 *  @param {int} start Index for the current display starting point in the
-	 *    display array
-	 *  @param {int} end Index for the current display ending point in the
-	 *    display array
-	 *  @param {array int} display Index array to translate the visual position
-	 *    to the full data array
-	 *
-	 *  @dtopt Callbacks
-	 *  @name DataTable.defaults.headerCallback
-	 *
-	 *  @example
-	 *    $(document).ready( function() {
+    /**
+     * This function is called on every 'draw' event, and allows you to
+     * dynamically modify the header row. This can be used to calculate and
+     * display useful information about the table.
+     *  @type function
+     *  @param {node} head "TR" element for the header
+     *  @param {array} data Full table data (as derived from the original HTML)
+     *  @param {int} start Index for the current display starting point in the
+     *    display array
+     *  @param {int} end Index for the current display ending point in the
+     *    display array
+     *  @param {array int} display Index array to translate the visual position
+     *    to the full data array
+     *
+     *  @dtopt Callbacks
+     *  @name DataTable.defaults.headerCallback
+     *
+     *  @example
+     *    $(document).ready( function() {
 	 *      $('#example').dataTable( {
 	 *        "fheaderCallback": function( head, data, start, end, display ) {
 	 *          head.getElementsByTagName('th')[0].innerHTML = "Displaying "+(end-start)+" records";
 	 *        }
 	 *      } );
 	 *    } )
-	 */
-	"fnHeaderCallback": null,
+     */
+    "fnHeaderCallback": null,
 
 
-	/**
-	 * The information element can be used to convey information about the current
-	 * state of the table. Although the internationalisation options presented by
-	 * DataTables are quite capable of dealing with most customisations, there may
-	 * be times where you wish to customise the string further. This callback
-	 * allows you to do exactly that.
-	 *  @type function
-	 *  @param {object} oSettings DataTables settings object
-	 *  @param {int} start Starting position in data for the draw
-	 *  @param {int} end End position in data for the draw
-	 *  @param {int} max Total number of rows in the table (regardless of
-	 *    filtering)
-	 *  @param {int} total Total number of rows in the data set, after filtering
-	 *  @param {string} pre The string that DataTables has formatted using it's
-	 *    own rules
-	 *  @returns {string} The string to be displayed in the information element.
-	 *
-	 *  @dtopt Callbacks
-	 *  @name DataTable.defaults.infoCallback
-	 *
-	 *  @example
-	 *    $('#example').dataTable( {
+    /**
+     * The information element can be used to convey information about the current
+     * state of the table. Although the internationalisation options presented by
+     * DataTables are quite capable of dealing with most customisations, there may
+     * be times where you wish to customise the string further. This callback
+     * allows you to do exactly that.
+     *  @type function
+     *  @param {object} oSettings DataTables settings object
+     *  @param {int} start Starting position in data for the draw
+     *  @param {int} end End position in data for the draw
+     *  @param {int} max Total number of rows in the table (regardless of
+     *    filtering)
+     *  @param {int} total Total number of rows in the data set, after filtering
+     *  @param {string} pre The string that DataTables has formatted using it's
+     *    own rules
+     *  @returns {string} The string to be displayed in the information element.
+     *
+     *  @dtopt Callbacks
+     *  @name DataTable.defaults.infoCallback
+     *
+     *  @example
+     *    $('#example').dataTable( {
 	 *      "infoCallback": function( settings, start, end, max, total, pre ) {
 	 *        return start +" to "+ end;
 	 *      }
 	 *    } );
-	 */
-	"fnInfoCallback": null,
+     */
+    "fnInfoCallback": null,
 
 
-	/**
-	 * Called when the table has been initialised. Normally DataTables will
-	 * initialise sequentially and there will be no need for this function,
-	 * however, this does not hold true when using external language information
-	 * since that is obtained using an async XHR call.
-	 *  @type function
-	 *  @param {object} settings DataTables settings object
-	 *  @param {object} json The JSON object request from the server - only
-	 *    present if client-side Ajax sourced data is used
-	 *
-	 *  @dtopt Callbacks
-	 *  @name DataTable.defaults.initComplete
-	 *
-	 *  @example
-	 *    $(document).ready( function() {
+    /**
+     * Called when the table has been initialised. Normally DataTables will
+     * initialise sequentially and there will be no need for this function,
+     * however, this does not hold true when using external language information
+     * since that is obtained using an async XHR call.
+     *  @type function
+     *  @param {object} settings DataTables settings object
+     *  @param {object} json The JSON object request from the server - only
+     *    present if client-side Ajax sourced data is used
+     *
+     *  @dtopt Callbacks
+     *  @name DataTable.defaults.initComplete
+     *
+     *  @example
+     *    $(document).ready( function() {
 	 *      $('#example').dataTable( {
 	 *        "initComplete": function(settings, json) {
 	 *          alert( 'DataTables has finished its initialisation.' );
 	 *        }
 	 *      } );
 	 *    } )
-	 */
-	"fnInitComplete": null,
+     */
+    "fnInitComplete": null,
 
 
-	/**
-	 * Called at the very start of each table draw and can be used to cancel the
-	 * draw by returning false, any other return (including undefined) results in
-	 * the full draw occurring).
-	 *  @type function
-	 *  @param {object} settings DataTables settings object
-	 *  @returns {boolean} False will cancel the draw, anything else (including no
-	 *    return) will allow it to complete.
-	 *
-	 *  @dtopt Callbacks
-	 *  @name DataTable.defaults.preDrawCallback
-	 *
-	 *  @example
-	 *    $(document).ready( function() {
+    /**
+     * Called at the very start of each table draw and can be used to cancel the
+     * draw by returning false, any other return (including undefined) results in
+     * the full draw occurring).
+     *  @type function
+     *  @param {object} settings DataTables settings object
+     *  @returns {boolean} False will cancel the draw, anything else (including no
+     *    return) will allow it to complete.
+     *
+     *  @dtopt Callbacks
+     *  @name DataTable.defaults.preDrawCallback
+     *
+     *  @example
+     *    $(document).ready( function() {
 	 *      $('#example').dataTable( {
 	 *        "preDrawCallback": function( settings ) {
 	 *          if ( $('#test').val() == 1 ) {
@@ -1004,26 +1004,26 @@ DataTable.defaults = {
 	 *        }
 	 *      } );
 	 *    } );
-	 */
-	"fnPreDrawCallback": null,
+     */
+    "fnPreDrawCallback": null,
 
 
-	/**
-	 * This function allows you to 'post process' each row after it have been
-	 * generated for each table draw, but before it is rendered on screen. This
-	 * function might be used for setting the row class name etc.
-	 *  @type function
-	 *  @param {node} row "TR" element for the current row
-	 *  @param {array} data Raw data array for this row
-	 *  @param {int} displayIndex The display index for the current table draw
-	 *  @param {int} displayIndexFull The index of the data in the full list of
-	 *    rows (after filtering)
-	 *
-	 *  @dtopt Callbacks
-	 *  @name DataTable.defaults.rowCallback
-	 *
-	 *  @example
-	 *    $(document).ready( function() {
+    /**
+     * This function allows you to 'post process' each row after it have been
+     * generated for each table draw, but before it is rendered on screen. This
+     * function might be used for setting the row class name etc.
+     *  @type function
+     *  @param {node} row "TR" element for the current row
+     *  @param {array} data Raw data array for this row
+     *  @param {int} displayIndex The display index for the current table draw
+     *  @param {int} displayIndexFull The index of the data in the full list of
+     *    rows (after filtering)
+     *
+     *  @dtopt Callbacks
+     *  @name DataTable.defaults.rowCallback
+     *
+     *  @example
+     *    $(document).ready( function() {
 	 *      $('#example').dataTable( {
 	 *        "rowCallback": function( row, data, displayIndex, displayIndexFull ) {
 	 *          // Bold the grade for all 'A' grade browsers
@@ -1033,79 +1033,79 @@ DataTable.defaults = {
 	 *        }
 	 *      } );
 	 *    } );
-	 */
-	"fnRowCallback": null,
+     */
+    "fnRowCallback": null,
 
 
-	/**
-	 * __Deprecated__ The functionality provided by this parameter has now been
-	 * superseded by that provided through `ajax`, which should be used instead.
-	 *
-	 * This parameter allows you to override the default function which obtains
-	 * the data from the server so something more suitable for your application.
-	 * For example you could use POST data, or pull information from a Gears or
-	 * AIR database.
-	 *  @type function
-	 *  @member
-	 *  @param {string} source HTTP source to obtain the data from (`ajax`)
-	 *  @param {array} data A key/value pair object containing the data to send
-	 *    to the server
-	 *  @param {function} callback to be called on completion of the data get
-	 *    process that will draw the data on the page.
-	 *  @param {object} settings DataTables settings object
-	 *
-	 *  @dtopt Callbacks
-	 *  @dtopt Server-side
-	 *  @name DataTable.defaults.serverData
-	 *
-	 *  @deprecated 1.10. Please use `ajax` for this functionality now.
-	 */
-	"fnServerData": null,
+    /**
+     * __Deprecated__ The functionality provided by this parameter has now been
+     * superseded by that provided through `ajax`, which should be used instead.
+     *
+     * This parameter allows you to override the default function which obtains
+     * the data from the server so something more suitable for your application.
+     * For example you could use POST data, or pull information from a Gears or
+     * AIR database.
+     *  @type function
+     *  @member
+     *  @param {string} source HTTP source to obtain the data from (`ajax`)
+     *  @param {array} data A key/value pair object containing the data to send
+     *    to the server
+     *  @param {function} callback to be called on completion of the data get
+     *    process that will draw the data on the page.
+     *  @param {object} settings DataTables settings object
+     *
+     *  @dtopt Callbacks
+     *  @dtopt Server-side
+     *  @name DataTable.defaults.serverData
+     *
+     *  @deprecated 1.10. Please use `ajax` for this functionality now.
+     */
+    "fnServerData": null,
 
 
-	/**
-	 * __Deprecated__ The functionality provided by this parameter has now been
-	 * superseded by that provided through `ajax`, which should be used instead.
-	 *
-	 *  It is often useful to send extra data to the server when making an Ajax
-	 * request - for example custom filtering information, and this callback
-	 * function makes it trivial to send extra information to the server. The
-	 * passed in parameter is the data set that has been constructed by
-	 * DataTables, and you can add to this or modify it as you require.
-	 *  @type function
-	 *  @param {array} data Data array (array of objects which are name/value
-	 *    pairs) that has been constructed by DataTables and will be sent to the
-	 *    server. In the case of Ajax sourced data with server-side processing
-	 *    this will be an empty array, for server-side processing there will be a
-	 *    significant number of parameters!
-	 *  @returns {undefined} Ensure that you modify the data array passed in,
-	 *    as this is passed by reference.
-	 *
-	 *  @dtopt Callbacks
-	 *  @dtopt Server-side
-	 *  @name DataTable.defaults.serverParams
-	 *
-	 *  @deprecated 1.10. Please use `ajax` for this functionality now.
-	 */
-	"fnServerParams": null,
+    /**
+     * __Deprecated__ The functionality provided by this parameter has now been
+     * superseded by that provided through `ajax`, which should be used instead.
+     *
+     *  It is often useful to send extra data to the server when making an Ajax
+     * request - for example custom filtering information, and this callback
+     * function makes it trivial to send extra information to the server. The
+     * passed in parameter is the data set that has been constructed by
+     * DataTables, and you can add to this or modify it as you require.
+     *  @type function
+     *  @param {array} data Data array (array of objects which are name/value
+     *    pairs) that has been constructed by DataTables and will be sent to the
+     *    server. In the case of Ajax sourced data with server-side processing
+     *    this will be an empty array, for server-side processing there will be a
+     *    significant number of parameters!
+     *  @returns {undefined} Ensure that you modify the data array passed in,
+     *    as this is passed by reference.
+     *
+     *  @dtopt Callbacks
+     *  @dtopt Server-side
+     *  @name DataTable.defaults.serverParams
+     *
+     *  @deprecated 1.10. Please use `ajax` for this functionality now.
+     */
+    "fnServerParams": null,
 
 
-	/**
-	 * Load the table state. With this function you can define from where, and how, the
-	 * state of a table is loaded. By default DataTables will load from `localStorage`
-	 * but you might wish to use a server-side database or cookies.
-	 *  @type function
-	 *  @member
-	 *  @param {object} settings DataTables settings object
-	 *  @param {object} callback Callback that can be executed when done. It
-	 *    should be passed the loaded state object.
-	 *  @return {object} The DataTables state object to be loaded
-	 *
-	 *  @dtopt Callbacks
-	 *  @name DataTable.defaults.stateLoadCallback
-	 *
-	 *  @example
-	 *    $(document).ready( function() {
+    /**
+     * Load the table state. With this function you can define from where, and how, the
+     * state of a table is loaded. By default DataTables will load from `localStorage`
+     * but you might wish to use a server-side database or cookies.
+     *  @type function
+     *  @member
+     *  @param {object} settings DataTables settings object
+     *  @param {object} callback Callback that can be executed when done. It
+     *    should be passed the loaded state object.
+     *  @return {object} The DataTables state object to be loaded
+     *
+     *  @dtopt Callbacks
+     *  @name DataTable.defaults.stateLoadCallback
+     *
+     *  @example
+     *    $(document).ready( function() {
 	 *      $('#example').dataTable( {
 	 *        "stateSave": true,
 	 *        "stateLoadCallback": function (settings, callback) {
@@ -1119,34 +1119,34 @@ DataTable.defaults = {
 	 *        }
 	 *      } );
 	 *    } );
-	 */
-	"fnStateLoadCallback": function ( settings ) {
-		try {
-			return JSON.parse(
-				(settings.iStateDuration === -1 ? sessionStorage : localStorage).getItem(
-					'DataTables_'+settings.sInstance+'_'+location.pathname
-				)
-			);
-		} catch (e) {}
-	},
+     */
+    "fnStateLoadCallback": function ( settings ) {
+        try {
+            return JSON.parse(
+                (settings.iStateDuration === -1 ? sessionStorage : localStorage).getItem(
+                    'DataTables_'+settings.sInstance+'_'+location.pathname
+                )
+            );
+        } catch (e) {}
+    },
 
 
-	/**
-	 * Callback which allows modification of the saved state prior to loading that state.
-	 * This callback is called when the table is loading state from the stored data, but
-	 * prior to the settings object being modified by the saved state. Note that for
-	 * plug-in authors, you should use the `stateLoadParams` event to load parameters for
-	 * a plug-in.
-	 *  @type function
-	 *  @param {object} settings DataTables settings object
-	 *  @param {object} data The state object that is to be loaded
-	 *
-	 *  @dtopt Callbacks
-	 *  @name DataTable.defaults.stateLoadParams
-	 *
-	 *  @example
-	 *    // Remove a saved filter, so filtering is never loaded
-	 *    $(document).ready( function() {
+    /**
+     * Callback which allows modification of the saved state prior to loading that state.
+     * This callback is called when the table is loading state from the stored data, but
+     * prior to the settings object being modified by the saved state. Note that for
+     * plug-in authors, you should use the `stateLoadParams` event to load parameters for
+     * a plug-in.
+     *  @type function
+     *  @param {object} settings DataTables settings object
+     *  @param {object} data The state object that is to be loaded
+     *
+     *  @dtopt Callbacks
+     *  @name DataTable.defaults.stateLoadParams
+     *
+     *  @example
+     *    // Remove a saved filter, so filtering is never loaded
+     *    $(document).ready( function() {
 	 *      $('#example').dataTable( {
 	 *        "stateSave": true,
 	 *        "stateLoadParams": function (settings, data) {
@@ -1154,10 +1154,10 @@ DataTable.defaults = {
 	 *        }
 	 *      } );
 	 *    } );
-	 *
-	 *  @example
-	 *    // Disallow state loading by returning false
-	 *    $(document).ready( function() {
+     *
+     *  @example
+     *    // Disallow state loading by returning false
+     *    $(document).ready( function() {
 	 *      $('#example').dataTable( {
 	 *        "stateSave": true,
 	 *        "stateLoadParams": function (settings, data) {
@@ -1165,23 +1165,23 @@ DataTable.defaults = {
 	 *        }
 	 *      } );
 	 *    } );
-	 */
-	"fnStateLoadParams": null,
+     */
+    "fnStateLoadParams": null,
 
 
-	/**
-	 * Callback that is called when the state has been loaded from the state saving method
-	 * and the DataTables settings object has been modified as a result of the loaded state.
-	 *  @type function
-	 *  @param {object} settings DataTables settings object
-	 *  @param {object} data The state object that was loaded
-	 *
-	 *  @dtopt Callbacks
-	 *  @name DataTable.defaults.stateLoaded
-	 *
-	 *  @example
-	 *    // Show an alert with the filtering value that was saved
-	 *    $(document).ready( function() {
+    /**
+     * Callback that is called when the state has been loaded from the state saving method
+     * and the DataTables settings object has been modified as a result of the loaded state.
+     *  @type function
+     *  @param {object} settings DataTables settings object
+     *  @param {object} data The state object that was loaded
+     *
+     *  @dtopt Callbacks
+     *  @name DataTable.defaults.stateLoaded
+     *
+     *  @example
+     *    // Show an alert with the filtering value that was saved
+     *    $(document).ready( function() {
 	 *      $('#example').dataTable( {
 	 *        "stateSave": true,
 	 *        "stateLoaded": function (settings, data) {
@@ -1189,24 +1189,24 @@ DataTable.defaults = {
 	 *        }
 	 *      } );
 	 *    } );
-	 */
-	"fnStateLoaded": null,
+     */
+    "fnStateLoaded": null,
 
 
-	/**
-	 * Save the table state. This function allows you to define where and how the state
-	 * information for the table is stored By default DataTables will use `localStorage`
-	 * but you might wish to use a server-side database or cookies.
-	 *  @type function
-	 *  @member
-	 *  @param {object} settings DataTables settings object
-	 *  @param {object} data The state object to be saved
-	 *
-	 *  @dtopt Callbacks
-	 *  @name DataTable.defaults.stateSaveCallback
-	 *
-	 *  @example
-	 *    $(document).ready( function() {
+    /**
+     * Save the table state. This function allows you to define where and how the state
+     * information for the table is stored By default DataTables will use `localStorage`
+     * but you might wish to use a server-side database or cookies.
+     *  @type function
+     *  @member
+     *  @param {object} settings DataTables settings object
+     *  @param {object} data The state object to be saved
+     *
+     *  @dtopt Callbacks
+     *  @name DataTable.defaults.stateSaveCallback
+     *
+     *  @example
+     *    $(document).ready( function() {
 	 *      $('#example').dataTable( {
 	 *        "stateSave": true,
 	 *        "stateSaveCallback": function (settings, data) {
@@ -1221,33 +1221,33 @@ DataTable.defaults = {
 	 *        }
 	 *      } );
 	 *    } );
-	 */
-	"fnStateSaveCallback": function ( settings, data ) {
-		try {
-			(settings.iStateDuration === -1 ? sessionStorage : localStorage).setItem(
-				'DataTables_'+settings.sInstance+'_'+location.pathname,
-				JSON.stringify( data )
-			);
-		} catch (e) {}
-	},
+     */
+    "fnStateSaveCallback": function ( settings, data ) {
+        try {
+            (settings.iStateDuration === -1 ? sessionStorage : localStorage).setItem(
+                'DataTables_'+settings.sInstance+'_'+location.pathname,
+                JSON.stringify( data )
+            );
+        } catch (e) {}
+    },
 
 
-	/**
-	 * Callback which allows modification of the state to be saved. Called when the table
-	 * has changed state a new state save is required. This method allows modification of
-	 * the state saving object prior to actually doing the save, including addition or
-	 * other state properties or modification. Note that for plug-in authors, you should
-	 * use the `stateSaveParams` event to save parameters for a plug-in.
-	 *  @type function
-	 *  @param {object} settings DataTables settings object
-	 *  @param {object} data The state object to be saved
-	 *
-	 *  @dtopt Callbacks
-	 *  @name DataTable.defaults.stateSaveParams
-	 *
-	 *  @example
-	 *    // Remove a saved filter, so filtering is never saved
-	 *    $(document).ready( function() {
+    /**
+     * Callback which allows modification of the state to be saved. Called when the table
+     * has changed state a new state save is required. This method allows modification of
+     * the state saving object prior to actually doing the save, including addition or
+     * other state properties or modification. Note that for plug-in authors, you should
+     * use the `stateSaveParams` event to save parameters for a plug-in.
+     *  @type function
+     *  @param {object} settings DataTables settings object
+     *  @param {object} data The state object to be saved
+     *
+     *  @dtopt Callbacks
+     *  @name DataTable.defaults.stateSaveParams
+     *
+     *  @example
+     *    // Remove a saved filter, so filtering is never saved
+     *    $(document).ready( function() {
 	 *      $('#example').dataTable( {
 	 *        "stateSave": true,
 	 *        "stateSaveParams": function (settings, data) {
@@ -1255,61 +1255,61 @@ DataTable.defaults = {
 	 *        }
 	 *      } );
 	 *    } );
-	 */
-	"fnStateSaveParams": null,
+     */
+    "fnStateSaveParams": null,
 
 
-	/**
-	 * Duration for which the saved state information is considered valid. After this period
-	 * has elapsed the state will be returned to the default.
-	 * Value is given in seconds.
-	 *  @type int
-	 *  @default 7200 <i>(2 hours)</i>
-	 *
-	 *  @dtopt Options
-	 *  @name DataTable.defaults.stateDuration
-	 *
-	 *  @example
-	 *    $(document).ready( function() {
+    /**
+     * Duration for which the saved state information is considered valid. After this period
+     * has elapsed the state will be returned to the default.
+     * Value is given in seconds.
+     *  @type int
+     *  @default 7200 <i>(2 hours)</i>
+     *
+     *  @dtopt Options
+     *  @name DataTable.defaults.stateDuration
+     *
+     *  @example
+     *    $(document).ready( function() {
 	 *      $('#example').dataTable( {
 	 *        "stateDuration": 60*60*24; // 1 day
 	 *      } );
 	 *    } )
-	 */
-	"iStateDuration": 7200,
+     */
+    "iStateDuration": 7200,
 
 
-	/**
-	 * When enabled DataTables will not make a request to the server for the first
-	 * page draw - rather it will use the data already on the page (no sorting etc
-	 * will be applied to it), thus saving on an XHR at load time. `deferLoading`
-	 * is used to indicate that deferred loading is required, but it is also used
-	 * to tell DataTables how many records there are in the full table (allowing
-	 * the information element and pagination to be displayed correctly). In the case
-	 * where a filtering is applied to the table on initial load, this can be
-	 * indicated by giving the parameter as an array, where the first element is
-	 * the number of records available after filtering and the second element is the
-	 * number of records without filtering (allowing the table information element
-	 * to be shown correctly).
-	 *  @type int | array
-	 *  @default null
-	 *
-	 *  @dtopt Options
-	 *  @name DataTable.defaults.deferLoading
-	 *
-	 *  @example
-	 *    // 57 records available in the table, no filtering applied
-	 *    $(document).ready( function() {
+    /**
+     * When enabled DataTables will not make a request to the server for the first
+     * page draw - rather it will use the data already on the page (no sorting etc
+     * will be applied to it), thus saving on an XHR at load time. `deferLoading`
+     * is used to indicate that deferred loading is required, but it is also used
+     * to tell DataTables how many records there are in the full table (allowing
+     * the information element and pagination to be displayed correctly). In the case
+     * where a filtering is applied to the table on initial load, this can be
+     * indicated by giving the parameter as an array, where the first element is
+     * the number of records available after filtering and the second element is the
+     * number of records without filtering (allowing the table information element
+     * to be shown correctly).
+     *  @type int | array
+     *  @default null
+     *
+     *  @dtopt Options
+     *  @name DataTable.defaults.deferLoading
+     *
+     *  @example
+     *    // 57 records available in the table, no filtering applied
+     *    $(document).ready( function() {
 	 *      $('#example').dataTable( {
 	 *        "serverSide": true,
 	 *        "ajax": "scripts/server_processing.php",
 	 *        "deferLoading": 57
 	 *      } );
 	 *    } );
-	 *
-	 *  @example
-	 *    // 57 records after filtering, 100 without filtering (an initial filter applied)
-	 *    $(document).ready( function() {
+     *
+     *  @example
+     *    // 57 records after filtering, 100 without filtering (an initial filter applied)
+     *    $(document).ready( function() {
 	 *      $('#example').dataTable( {
 	 *        "serverSide": true,
 	 *        "ajax": "scripts/server_processing.php",
@@ -1319,113 +1319,113 @@ DataTable.defaults = {
 	 *        }
 	 *      } );
 	 *    } );
-	 */
-	"iDeferLoading": null,
+     */
+    "iDeferLoading": null,
 
 
-	/**
-	 * Number of rows to display on a single page when using pagination. If
-	 * feature enabled (`lengthChange`) then the end user will be able to override
-	 * this to a custom setting using a pop-up menu.
-	 *  @type int
-	 *  @default 10
-	 *
-	 *  @dtopt Options
-	 *  @name DataTable.defaults.pageLength
-	 *
-	 *  @example
-	 *    $(document).ready( function() {
+    /**
+     * Number of rows to display on a single page when using pagination. If
+     * feature enabled (`lengthChange`) then the end user will be able to override
+     * this to a custom setting using a pop-up menu.
+     *  @type int
+     *  @default 10
+     *
+     *  @dtopt Options
+     *  @name DataTable.defaults.pageLength
+     *
+     *  @example
+     *    $(document).ready( function() {
 	 *      $('#example').dataTable( {
 	 *        "pageLength": 50
 	 *      } );
 	 *    } )
-	 */
-	"iDisplayLength": 10,
+     */
+    "iDisplayLength": 10,
 
 
-	/**
-	 * Define the starting point for data display when using DataTables with
-	 * pagination. Note that this parameter is the number of records, rather than
-	 * the page number, so if you have 10 records per page and want to start on
-	 * the third page, it should be "20".
-	 *  @type int
-	 *  @default 0
-	 *
-	 *  @dtopt Options
-	 *  @name DataTable.defaults.displayStart
-	 *
-	 *  @example
-	 *    $(document).ready( function() {
+    /**
+     * Define the starting point for data display when using DataTables with
+     * pagination. Note that this parameter is the number of records, rather than
+     * the page number, so if you have 10 records per page and want to start on
+     * the third page, it should be "20".
+     *  @type int
+     *  @default 0
+     *
+     *  @dtopt Options
+     *  @name DataTable.defaults.displayStart
+     *
+     *  @example
+     *    $(document).ready( function() {
 	 *      $('#example').dataTable( {
 	 *        "displayStart": 20
 	 *      } );
 	 *    } )
-	 */
-	"iDisplayStart": 0,
+     */
+    "iDisplayStart": 0,
 
 
-	/**
-	 * By default DataTables allows keyboard navigation of the table (sorting, paging,
-	 * and filtering) by adding a `tabindex` attribute to the required elements. This
-	 * allows you to tab through the controls and press the enter key to activate them.
-	 * The tabindex is default 0, meaning that the tab follows the flow of the document.
-	 * You can overrule this using this parameter if you wish. Use a value of -1 to
-	 * disable built-in keyboard navigation.
-	 *  @type int
-	 *  @default 0
-	 *
-	 *  @dtopt Options
-	 *  @name DataTable.defaults.tabIndex
-	 *
-	 *  @example
-	 *    $(document).ready( function() {
+    /**
+     * By default DataTables allows keyboard navigation of the table (sorting, paging,
+     * and filtering) by adding a `tabindex` attribute to the required elements. This
+     * allows you to tab through the controls and press the enter key to activate them.
+     * The tabindex is default 0, meaning that the tab follows the flow of the document.
+     * You can overrule this using this parameter if you wish. Use a value of -1 to
+     * disable built-in keyboard navigation.
+     *  @type int
+     *  @default 0
+     *
+     *  @dtopt Options
+     *  @name DataTable.defaults.tabIndex
+     *
+     *  @example
+     *    $(document).ready( function() {
 	 *      $('#example').dataTable( {
 	 *        "tabIndex": 1
 	 *      } );
 	 *    } );
-	 */
-	"iTabIndex": 0,
+     */
+    "iTabIndex": 0,
 
 
-	/**
-	 * Classes that DataTables assigns to the various components and features
-	 * that it adds to the HTML table. This allows classes to be configured
-	 * during initialisation in addition to through the static
-	 * {@link DataTable.ext.oStdClasses} object).
-	 *  @namespace
-	 *  @name DataTable.defaults.classes
-	 */
-	"oClasses": {},
+    /**
+     * Classes that DataTables assigns to the various components and features
+     * that it adds to the HTML table. This allows classes to be configured
+     * during initialisation in addition to through the static
+     * {@link DataTable.ext.oStdClasses} object).
+     *  @namespace
+     *  @name DataTable.defaults.classes
+     */
+    "oClasses": {},
 
 
-	/**
-	 * All strings that DataTables uses in the user interface that it creates
-	 * are defined in this object, allowing you to modified them individually or
-	 * completely replace them all as required.
-	 *  @namespace
-	 *  @name DataTable.defaults.language
-	 */
-	"oLanguage": {
-		/**
-		 * Strings that are used for WAI-ARIA labels and controls only (these are not
-		 * actually visible on the page, but will be read by screenreaders, and thus
-		 * must be internationalised as well).
-		 *  @namespace
-		 *  @name DataTable.defaults.language.aria
-		 */
-		"oAria": {
-			/**
-			 * ARIA label that is added to the table headers when the column may be
-			 * sorted ascending by activing the column (click or return when focused).
-			 * Note that the column header is prefixed to this string.
-			 *  @type string
-			 *  @default : activate to sort column ascending
-			 *
-			 *  @dtopt Language
-			 *  @name DataTable.defaults.language.aria.sortAscending
-			 *
-			 *  @example
-			 *    $(document).ready( function() {
+    /**
+     * All strings that DataTables uses in the user interface that it creates
+     * are defined in this object, allowing you to modified them individually or
+     * completely replace them all as required.
+     *  @namespace
+     *  @name DataTable.defaults.language
+     */
+    "oLanguage": {
+        /**
+         * Strings that are used for WAI-ARIA labels and controls only (these are not
+         * actually visible on the page, but will be read by screenreaders, and thus
+         * must be internationalised as well).
+         *  @namespace
+         *  @name DataTable.defaults.language.aria
+         */
+        "oAria": {
+            /**
+             * ARIA label that is added to the table headers when the column may be
+             * sorted ascending by activing the column (click or return when focused).
+             * Note that the column header is prefixed to this string.
+             *  @type string
+             *  @default : activate to sort column ascending
+             *
+             *  @dtopt Language
+             *  @name DataTable.defaults.language.aria.sortAscending
+             *
+             *  @example
+             *    $(document).ready( function() {
 			 *      $('#example').dataTable( {
 			 *        "language": {
 			 *          "aria": {
@@ -1434,21 +1434,21 @@ DataTable.defaults = {
 			 *        }
 			 *      } );
 			 *    } );
-			 */
-			"sSortAscending": ": activate to sort column ascending",
+             */
+            "sSortAscending": ": activate to sort column ascending",
 
-			/**
-			 * ARIA label that is added to the table headers when the column may be
-			 * sorted descending by activing the column (click or return when focused).
-			 * Note that the column header is prefixed to this string.
-			 *  @type string
-			 *  @default : activate to sort column ascending
-			 *
-			 *  @dtopt Language
-			 *  @name DataTable.defaults.language.aria.sortDescending
-			 *
-			 *  @example
-			 *    $(document).ready( function() {
+            /**
+             * ARIA label that is added to the table headers when the column may be
+             * sorted descending by activing the column (click or return when focused).
+             * Note that the column header is prefixed to this string.
+             *  @type string
+             *  @default : activate to sort column ascending
+             *
+             *  @dtopt Language
+             *  @name DataTable.defaults.language.aria.sortDescending
+             *
+             *  @example
+             *    $(document).ready( function() {
 			 *      $('#example').dataTable( {
 			 *        "language": {
 			 *          "aria": {
@@ -1457,28 +1457,28 @@ DataTable.defaults = {
 			 *        }
 			 *      } );
 			 *    } );
-			 */
-			"sSortDescending": ": activate to sort column descending"
-		},
+             */
+            "sSortDescending": ": activate to sort column descending"
+        },
 
-		/**
-		 * Pagination string used by DataTables for the built-in pagination
-		 * control types.
-		 *  @namespace
-		 *  @name DataTable.defaults.language.paginate
-		 */
-		"oPaginate": {
-			/**
-			 * Text to use when using the 'full_numbers' type of pagination for the
-			 * button to take the user to the first page.
-			 *  @type string
-			 *  @default First
-			 *
-			 *  @dtopt Language
-			 *  @name DataTable.defaults.language.paginate.first
-			 *
-			 *  @example
-			 *    $(document).ready( function() {
+        /**
+         * Pagination string used by DataTables for the built-in pagination
+         * control types.
+         *  @namespace
+         *  @name DataTable.defaults.language.paginate
+         */
+        "oPaginate": {
+            /**
+             * Text to use when using the 'full_numbers' type of pagination for the
+             * button to take the user to the first page.
+             *  @type string
+             *  @default First
+             *
+             *  @dtopt Language
+             *  @name DataTable.defaults.language.paginate.first
+             *
+             *  @example
+             *    $(document).ready( function() {
 			 *      $('#example').dataTable( {
 			 *        "language": {
 			 *          "paginate": {
@@ -1487,21 +1487,21 @@ DataTable.defaults = {
 			 *        }
 			 *      } );
 			 *    } );
-			 */
-			"sFirst": "First",
+             */
+            "sFirst": "First",
 
 
-			/**
-			 * Text to use when using the 'full_numbers' type of pagination for the
-			 * button to take the user to the last page.
-			 *  @type string
-			 *  @default Last
-			 *
-			 *  @dtopt Language
-			 *  @name DataTable.defaults.language.paginate.last
-			 *
-			 *  @example
-			 *    $(document).ready( function() {
+            /**
+             * Text to use when using the 'full_numbers' type of pagination for the
+             * button to take the user to the last page.
+             *  @type string
+             *  @default Last
+             *
+             *  @dtopt Language
+             *  @name DataTable.defaults.language.paginate.last
+             *
+             *  @example
+             *    $(document).ready( function() {
 			 *      $('#example').dataTable( {
 			 *        "language": {
 			 *          "paginate": {
@@ -1510,21 +1510,21 @@ DataTable.defaults = {
 			 *        }
 			 *      } );
 			 *    } );
-			 */
-			"sLast": "Last",
+             */
+            "sLast": "Last",
 
 
-			/**
-			 * Text to use for the 'next' pagination button (to take the user to the
-			 * next page).
-			 *  @type string
-			 *  @default Next
-			 *
-			 *  @dtopt Language
-			 *  @name DataTable.defaults.language.paginate.next
-			 *
-			 *  @example
-			 *    $(document).ready( function() {
+            /**
+             * Text to use for the 'next' pagination button (to take the user to the
+             * next page).
+             *  @type string
+             *  @default Next
+             *
+             *  @dtopt Language
+             *  @name DataTable.defaults.language.paginate.next
+             *
+             *  @example
+             *    $(document).ready( function() {
 			 *      $('#example').dataTable( {
 			 *        "language": {
 			 *          "paginate": {
@@ -1533,21 +1533,21 @@ DataTable.defaults = {
 			 *        }
 			 *      } );
 			 *    } );
-			 */
-			"sNext": "Next",
+             */
+            "sNext": "Next",
 
 
-			/**
-			 * Text to use for the 'previous' pagination button (to take the user to
-			 * the previous page).
-			 *  @type string
-			 *  @default Previous
-			 *
-			 *  @dtopt Language
-			 *  @name DataTable.defaults.language.paginate.previous
-			 *
-			 *  @example
-			 *    $(document).ready( function() {
+            /**
+             * Text to use for the 'previous' pagination button (to take the user to
+             * the previous page).
+             *  @type string
+             *  @default Previous
+             *
+             *  @dtopt Language
+             *  @name DataTable.defaults.language.paginate.previous
+             *
+             *  @example
+             *    $(document).ready( function() {
 			 *      $('#example').dataTable( {
 			 *        "language": {
 			 *          "paginate": {
@@ -1556,151 +1556,151 @@ DataTable.defaults = {
 			 *        }
 			 *      } );
 			 *    } );
-			 */
-			"sPrevious": "Previous"
-		},
+             */
+            "sPrevious": "Previous"
+        },
 
-		/**
-		 * This string is shown in preference to `zeroRecords` when the table is
-		 * empty of data (regardless of filtering). Note that this is an optional
-		 * parameter - if it is not given, the value of `zeroRecords` will be used
-		 * instead (either the default or given value).
-		 *  @type string
-		 *  @default No data available in table
-		 *
-		 *  @dtopt Language
-		 *  @name DataTable.defaults.language.emptyTable
-		 *
-		 *  @example
-		 *    $(document).ready( function() {
+        /**
+         * This string is shown in preference to `zeroRecords` when the table is
+         * empty of data (regardless of filtering). Note that this is an optional
+         * parameter - if it is not given, the value of `zeroRecords` will be used
+         * instead (either the default or given value).
+         *  @type string
+         *  @default No data available in table
+         *
+         *  @dtopt Language
+         *  @name DataTable.defaults.language.emptyTable
+         *
+         *  @example
+         *    $(document).ready( function() {
 		 *      $('#example').dataTable( {
 		 *        "language": {
 		 *          "emptyTable": "No data available in table"
 		 *        }
 		 *      } );
 		 *    } );
-		 */
-		"sEmptyTable": "No data available in table",
+         */
+        "sEmptyTable": "No data available in table",
 
 
-		/**
-		 * This string gives information to the end user about the information
-		 * that is current on display on the page. The following tokens can be
-		 * used in the string and will be dynamically replaced as the table
-		 * display updates. This tokens can be placed anywhere in the string, or
-		 * removed as needed by the language requires:
-		 *
-		 * * `\_START\_` - Display index of the first record on the current page
-		 * * `\_END\_` - Display index of the last record on the current page
-		 * * `\_TOTAL\_` - Number of records in the table after filtering
-		 * * `\_MAX\_` - Number of records in the table without filtering
-		 * * `\_PAGE\_` - Current page number
-		 * * `\_PAGES\_` - Total number of pages of data in the table
-		 *
-		 *  @type string
-		 *  @default Showing _START_ to _END_ of _TOTAL_ entries
-		 *
-		 *  @dtopt Language
-		 *  @name DataTable.defaults.language.info
-		 *
-		 *  @example
-		 *    $(document).ready( function() {
+        /**
+         * This string gives information to the end user about the information
+         * that is current on display on the page. The following tokens can be
+         * used in the string and will be dynamically replaced as the table
+         * display updates. This tokens can be placed anywhere in the string, or
+         * removed as needed by the language requires:
+         *
+         * * `\_START\_` - Display index of the first record on the current page
+         * * `\_END\_` - Display index of the last record on the current page
+         * * `\_TOTAL\_` - Number of records in the table after filtering
+         * * `\_MAX\_` - Number of records in the table without filtering
+         * * `\_PAGE\_` - Current page number
+         * * `\_PAGES\_` - Total number of pages of data in the table
+         *
+         *  @type string
+         *  @default Showing _START_ to _END_ of _TOTAL_ entries
+         *
+         *  @dtopt Language
+         *  @name DataTable.defaults.language.info
+         *
+         *  @example
+         *    $(document).ready( function() {
 		 *      $('#example').dataTable( {
 		 *        "language": {
 		 *          "info": "Showing page _PAGE_ of _PAGES_"
 		 *        }
 		 *      } );
 		 *    } );
-		 */
-		"sInfo": "Showing _START_ to _END_ of _TOTAL_ entries",
+         */
+        "sInfo": "Showing _START_ to _END_ of _TOTAL_ entries",
 
 
-		/**
-		 * Display information string for when the table is empty. Typically the
-		 * format of this string should match `info`.
-		 *  @type string
-		 *  @default Showing 0 to 0 of 0 entries
-		 *
-		 *  @dtopt Language
-		 *  @name DataTable.defaults.language.infoEmpty
-		 *
-		 *  @example
-		 *    $(document).ready( function() {
+        /**
+         * Display information string for when the table is empty. Typically the
+         * format of this string should match `info`.
+         *  @type string
+         *  @default Showing 0 to 0 of 0 entries
+         *
+         *  @dtopt Language
+         *  @name DataTable.defaults.language.infoEmpty
+         *
+         *  @example
+         *    $(document).ready( function() {
 		 *      $('#example').dataTable( {
 		 *        "language": {
 		 *          "infoEmpty": "No entries to show"
 		 *        }
 		 *      } );
 		 *    } );
-		 */
-		"sInfoEmpty": "Showing 0 to 0 of 0 entries",
+         */
+        "sInfoEmpty": "Showing 0 to 0 of 0 entries",
 
 
-		/**
-		 * When a user filters the information in a table, this string is appended
-		 * to the information (`info`) to give an idea of how strong the filtering
-		 * is. The variable _MAX_ is dynamically updated.
-		 *  @type string
-		 *  @default (filtered from _MAX_ total entries)
-		 *
-		 *  @dtopt Language
-		 *  @name DataTable.defaults.language.infoFiltered
-		 *
-		 *  @example
-		 *    $(document).ready( function() {
+        /**
+         * When a user filters the information in a table, this string is appended
+         * to the information (`info`) to give an idea of how strong the filtering
+         * is. The variable _MAX_ is dynamically updated.
+         *  @type string
+         *  @default (filtered from _MAX_ total entries)
+         *
+         *  @dtopt Language
+         *  @name DataTable.defaults.language.infoFiltered
+         *
+         *  @example
+         *    $(document).ready( function() {
 		 *      $('#example').dataTable( {
 		 *        "language": {
 		 *          "infoFiltered": " - filtering from _MAX_ records"
 		 *        }
 		 *      } );
 		 *    } );
-		 */
-		"sInfoFiltered": "(filtered from _MAX_ total entries)",
+         */
+        "sInfoFiltered": "(filtered from _MAX_ total entries)",
 
 
-		/**
-		 * If can be useful to append extra information to the info string at times,
-		 * and this variable does exactly that. This information will be appended to
-		 * the `info` (`infoEmpty` and `infoFiltered` in whatever combination they are
-		 * being used) at all times.
-		 *  @type string
-		 *  @default <i>Empty string</i>
-		 *
-		 *  @dtopt Language
-		 *  @name DataTable.defaults.language.infoPostFix
-		 *
-		 *  @example
-		 *    $(document).ready( function() {
+        /**
+         * If can be useful to append extra information to the info string at times,
+         * and this variable does exactly that. This information will be appended to
+         * the `info` (`infoEmpty` and `infoFiltered` in whatever combination they are
+         * being used) at all times.
+         *  @type string
+         *  @default <i>Empty string</i>
+         *
+         *  @dtopt Language
+         *  @name DataTable.defaults.language.infoPostFix
+         *
+         *  @example
+         *    $(document).ready( function() {
 		 *      $('#example').dataTable( {
 		 *        "language": {
 		 *          "infoPostFix": "All records shown are derived from real information."
 		 *        }
 		 *      } );
 		 *    } );
-		 */
-		"sInfoPostFix": "",
+         */
+        "sInfoPostFix": "",
 
 
-		/**
-		 * This decimal place operator is a little different from the other
-		 * language options since DataTables doesn't output floating point
-		 * numbers, so it won't ever use this for display of a number. Rather,
-		 * what this parameter does is modify the sort methods of the table so
-		 * that numbers which are in a format which has a character other than
-		 * a period (`.`) as a decimal place will be sorted numerically.
-		 *
-		 * Note that numbers with different decimal places cannot be shown in
-		 * the same table and still be sortable, the table must be consistent.
-		 * However, multiple different tables on the page can use different
-		 * decimal place characters.
-		 *  @type string
-		 *  @default 
-		 *
-		 *  @dtopt Language
-		 *  @name DataTable.defaults.language.decimal
-		 *
-		 *  @example
-		 *    $(document).ready( function() {
+        /**
+         * This decimal place operator is a little different from the other
+         * language options since DataTables doesn't output floating point
+         * numbers, so it won't ever use this for display of a number. Rather,
+         * what this parameter does is modify the sort methods of the table so
+         * that numbers which are in a format which has a character other than
+         * a period (`.`) as a decimal place will be sorted numerically.
+         *
+         * Note that numbers with different decimal places cannot be shown in
+         * the same table and still be sortable, the table must be consistent.
+         * However, multiple different tables on the page can use different
+         * decimal place characters.
+         *  @type string
+         *  @default
+         *
+         *  @dtopt Language
+         *  @name DataTable.defaults.language.decimal
+         *
+         *  @example
+         *    $(document).ready( function() {
 		 *      $('#example').dataTable( {
 		 *        "language": {
 		 *          "decimal": ","
@@ -1708,57 +1708,57 @@ DataTable.defaults = {
 		 *        }
 		 *      } );
 		 *    } );
-		 */
-		"sDecimal": "",
+         */
+        "sDecimal": "",
 
 
-		/**
-		 * DataTables has a build in number formatter (`formatNumber`) which is
-		 * used to format large numbers that are used in the table information.
-		 * By default a comma is used, but this can be trivially changed to any
-		 * character you wish with this parameter.
-		 *  @type string
-		 *  @default ,
-		 *
-		 *  @dtopt Language
-		 *  @name DataTable.defaults.language.thousands
-		 *
-		 *  @example
-		 *    $(document).ready( function() {
+        /**
+         * DataTables has a build in number formatter (`formatNumber`) which is
+         * used to format large numbers that are used in the table information.
+         * By default a comma is used, but this can be trivially changed to any
+         * character you wish with this parameter.
+         *  @type string
+         *  @default ,
+         *
+         *  @dtopt Language
+         *  @name DataTable.defaults.language.thousands
+         *
+         *  @example
+         *    $(document).ready( function() {
 		 *      $('#example').dataTable( {
 		 *        "language": {
 		 *          "thousands": "'"
 		 *        }
 		 *      } );
 		 *    } );
-		 */
-		"sThousands": ",",
+         */
+        "sThousands": ",",
 
 
-		/**
-		 * Detail the action that will be taken when the drop down menu for the
-		 * pagination length option is changed. The '_MENU_' variable is replaced
-		 * with a default select list of 10, 25, 50 and 100, and can be replaced
-		 * with a custom select box if required.
-		 *  @type string
-		 *  @default Show _MENU_ entries
-		 *
-		 *  @dtopt Language
-		 *  @name DataTable.defaults.language.lengthMenu
-		 *
-		 *  @example
-		 *    // Language change only
-		 *    $(document).ready( function() {
+        /**
+         * Detail the action that will be taken when the drop down menu for the
+         * pagination length option is changed. The '_MENU_' variable is replaced
+         * with a default select list of 10, 25, 50 and 100, and can be replaced
+         * with a custom select box if required.
+         *  @type string
+         *  @default Show _MENU_ entries
+         *
+         *  @dtopt Language
+         *  @name DataTable.defaults.language.lengthMenu
+         *
+         *  @example
+         *    // Language change only
+         *    $(document).ready( function() {
 		 *      $('#example').dataTable( {
 		 *        "language": {
 		 *          "lengthMenu": "Display _MENU_ records"
 		 *        }
 		 *      } );
 		 *    } );
-		 *
-		 *  @example
-		 *    // Language and options change
-		 *    $(document).ready( function() {
+         *
+         *  @example
+         *    // Language and options change
+         *    $(document).ready( function() {
 		 *      $('#example').dataTable( {
 		 *        "language": {
 		 *          "lengthMenu": 'Display <select>'+
@@ -1772,433 +1772,457 @@ DataTable.defaults = {
 		 *        }
 		 *      } );
 		 *    } );
-		 */
-		"sLengthMenu": "Show _MENU_ entries",
+         */
+        "sLengthMenu": "Show _MENU_ entries",
 
 
-		/**
-		 * When using Ajax sourced data and during the first draw when DataTables is
-		 * gathering the data, this message is shown in an empty row in the table to
-		 * indicate to the end user the the data is being loaded. Note that this
-		 * parameter is not used when loading data by server-side processing, just
-		 * Ajax sourced data with client-side processing.
-		 *  @type string
-		 *  @default Loading...
-		 *
-		 *  @dtopt Language
-		 *  @name DataTable.defaults.language.loadingRecords
-		 *
-		 *  @example
-		 *    $(document).ready( function() {
+        /**
+         * When using Ajax sourced data and during the first draw when DataTables is
+         * gathering the data, this message is shown in an empty row in the table to
+         * indicate to the end user the the data is being loaded. Note that this
+         * parameter is not used when loading data by server-side processing, just
+         * Ajax sourced data with client-side processing.
+         *  @type string
+         *  @default Loading...
+         *
+         *  @dtopt Language
+         *  @name DataTable.defaults.language.loadingRecords
+         *
+         *  @example
+         *    $(document).ready( function() {
 		 *      $('#example').dataTable( {
 		 *        "language": {
 		 *          "loadingRecords": "Please wait - loading..."
 		 *        }
 		 *      } );
 		 *    } );
-		 */
-		"sLoadingRecords": "Loading...",
+         */
+        "sLoadingRecords": "Loading...",
 
 
-		/**
-		 * Text which is displayed when the table is processing a user action
-		 * (usually a sort command or similar).
-		 *  @type string
-		 *  @default Processing...
-		 *
-		 *  @dtopt Language
-		 *  @name DataTable.defaults.language.processing
-		 *
-		 *  @example
-		 *    $(document).ready( function() {
+        /**
+         * Text which is displayed when the table is processing a user action
+         * (usually a sort command or similar).
+         *  @type string
+         *  @default Processing...
+         *
+         *  @dtopt Language
+         *  @name DataTable.defaults.language.processing
+         *
+         *  @example
+         *    $(document).ready( function() {
 		 *      $('#example').dataTable( {
 		 *        "language": {
 		 *          "processing": "DataTables is currently busy"
 		 *        }
 		 *      } );
 		 *    } );
-		 */
-		"sProcessing": "Processing...",
+         */
+        "sProcessing": "Processing...",
 
 
-		/**
-		 * Details the actions that will be taken when the user types into the
-		 * filtering input text box. The variable "_INPUT_", if used in the string,
-		 * is replaced with the HTML text box for the filtering input allowing
-		 * control over where it appears in the string. If "_INPUT_" is not given
-		 * then the input box is appended to the string automatically.
-		 *  @type string
-		 *  @default Search:
-		 *
-		 *  @dtopt Language
-		 *  @name DataTable.defaults.language.search
-		 *
-		 *  @example
-		 *    // Input text box will be appended at the end automatically
-		 *    $(document).ready( function() {
+        /**
+         * Details the actions that will be taken when the user types into the
+         * filtering input text box. The variable "_INPUT_", if used in the string,
+         * is replaced with the HTML text box for the filtering input allowing
+         * control over where it appears in the string. If "_INPUT_" is not given
+         * then the input box is appended to the string automatically.
+         *  @type string
+         *  @default Search:
+         *
+         *  @dtopt Language
+         *  @name DataTable.defaults.language.search
+         *
+         *  @example
+         *    // Input text box will be appended at the end automatically
+         *    $(document).ready( function() {
 		 *      $('#example').dataTable( {
 		 *        "language": {
 		 *          "search": "Filter records:"
 		 *        }
 		 *      } );
 		 *    } );
-		 *
-		 *  @example
-		 *    // Specify where the filter should appear
-		 *    $(document).ready( function() {
+         *
+         *  @example
+         *    // Specify where the filter should appear
+         *    $(document).ready( function() {
 		 *      $('#example').dataTable( {
 		 *        "language": {
 		 *          "search": "Apply filter _INPUT_ to table"
 		 *        }
 		 *      } );
 		 *    } );
-		 */
-		"sSearch": "Search:",
+         */
+        "sSearch": "Search:",
 
 
-		/**
-		 * Assign a `placeholder` attribute to the search `input` element
-		 *  @type string
-		 *  @default 
-		 *
-		 *  @dtopt Language
-		 *  @name DataTable.defaults.language.searchPlaceholder
-		 */
-		"sSearchPlaceholder": "",
+        /**
+         * Assign a `placeholder` attribute to the search `input` element
+         *  @type string
+         *  @default
+         *
+         *  @dtopt Language
+         *  @name DataTable.defaults.language.searchPlaceholder
+         */
+        "sSearchPlaceholder": "",
 
 
-		/**
-		 * All of the language information can be stored in a file on the
-		 * server-side, which DataTables will look up if this parameter is passed.
-		 * It must store the URL of the language file, which is in a JSON format,
-		 * and the object has the same properties as the oLanguage object in the
-		 * initialiser object (i.e. the above parameters). Please refer to one of
-		 * the example language files to see how this works in action.
-		 *  @type string
-		 *  @default <i>Empty string - i.e. disabled</i>
-		 *
-		 *  @dtopt Language
-		 *  @name DataTable.defaults.language.url
-		 *
-		 *  @example
-		 *    $(document).ready( function() {
+        /**
+         * All of the language information can be stored in a file on the
+         * server-side, which DataTables will look up if this parameter is passed.
+         * It must store the URL of the language file, which is in a JSON format,
+         * and the object has the same properties as the oLanguage object in the
+         * initialiser object (i.e. the above parameters). Please refer to one of
+         * the example language files to see how this works in action.
+         *  @type string
+         *  @default <i>Empty string - i.e. disabled</i>
+         *
+         *  @dtopt Language
+         *  @name DataTable.defaults.language.url
+         *
+         *  @example
+         *    $(document).ready( function() {
 		 *      $('#example').dataTable( {
 		 *        "language": {
 		 *          "url": "http://www.sprymedia.co.uk/dataTables/lang.txt"
 		 *        }
 		 *      } );
 		 *    } );
-		 */
-		"sUrl": "",
+         */
+        "sUrl": "",
 
 
-		/**
-		 * Text shown inside the table records when the is no information to be
-		 * displayed after filtering. `emptyTable` is shown when there is simply no
-		 * information in the table at all (regardless of filtering).
-		 *  @type string
-		 *  @default No matching records found
-		 *
-		 *  @dtopt Language
-		 *  @name DataTable.defaults.language.zeroRecords
-		 *
-		 *  @example
-		 *    $(document).ready( function() {
+        /**
+         * Text shown inside the table records when the is no information to be
+         * displayed after filtering. `emptyTable` is shown when there is simply no
+         * information in the table at all (regardless of filtering).
+         *  @type string
+         *  @default No matching records found
+         *
+         *  @dtopt Language
+         *  @name DataTable.defaults.language.zeroRecords
+         *
+         *  @example
+         *    $(document).ready( function() {
 		 *      $('#example').dataTable( {
 		 *        "language": {
 		 *          "zeroRecords": "No records to display"
 		 *        }
 		 *      } );
 		 *    } );
-		 */
-		"sZeroRecords": "No matching records found"
-	},
+         */
+        "sZeroRecords": "No matching records found"
+    },
 
 
-	/**
-	 * This parameter allows you to have define the global filtering state at
-	 * initialisation time. As an object the `search` parameter must be
-	 * defined, but all other parameters are optional. When `regex` is true,
-	 * the search string will be treated as a regular expression, when false
-	 * (default) it will be treated as a straight string. When `smart`
-	 * DataTables will use it's smart filtering methods (to word match at
-	 * any point in the data), when false this will not be done.
-	 *  @namespace
-	 *  @extends DataTable.models.oSearch
-	 *
-	 *  @dtopt Options
-	 *  @name DataTable.defaults.search
-	 *
-	 *  @example
-	 *    $(document).ready( function() {
+    /**
+     * This parameter allows you to have define the global filtering state at
+     * initialisation time. As an object the `search` parameter must be
+     * defined, but all other parameters are optional. When `regex` is true,
+     * the search string will be treated as a regular expression, when false
+     * (default) it will be treated as a straight string. When `smart`
+     * DataTables will use it's smart filtering methods (to word match at
+     * any point in the data), when false this will not be done.
+     *  @namespace
+     *  @extends DataTable.models.oSearch
+     *
+     *  @dtopt Options
+     *  @name DataTable.defaults.search
+     *
+     *  @example
+     *    $(document).ready( function() {
 	 *      $('#example').dataTable( {
 	 *        "search": {"search": "Initial search"}
 	 *      } );
 	 *    } )
-	 */
-	"oSearch": $.extend( {}, DataTable.models.oSearch ),
+     */
+    "oSearch": $.extend( {}, DataTable.models.oSearch ),
 
 
-	/**
-	 * __Deprecated__ The functionality provided by this parameter has now been
-	 * superseded by that provided through `ajax`, which should be used instead.
-	 *
-	 * By default DataTables will look for the property `data` (or `aaData` for
-	 * compatibility with DataTables 1.9-) when obtaining data from an Ajax
-	 * source or for server-side processing - this parameter allows that
-	 * property to be changed. You can use Javascript dotted object notation to
-	 * get a data source for multiple levels of nesting.
-	 *  @type string
-	 *  @default data
-	 *
-	 *  @dtopt Options
-	 *  @dtopt Server-side
-	 *  @name DataTable.defaults.ajaxDataProp
-	 *
-	 *  @deprecated 1.10. Please use `ajax` for this functionality now.
-	 */
-	"sAjaxDataProp": "data",
+    /**
+     * This parameter allows you to have define the global filtering state at
+     * initialisation time. As an object the `search` parameter must be
+     * defined, but all other parameters are optional. When `regex` is true,
+     * the search string will be treated as a regular expression, when false
+     * (default) it will be treated as a straight string. When `smart`
+     * DataTables will use it's smart filtering methods (to word match at
+     * any point in the data), when false this will not be done.
+     *  @namespace
+     *  @extends DataTable.models.oExclude
+     *
+     *  @dtopt Options
+     *  @name DataTable.defaults.exclude
+     *
+     *  @example
+     *    $(document).ready( function() {
+	 *      $('#example').dataTable( {
+	 *        "exclude": {"exclude": "Initial exclude"}
+	 *      } );
+	 *    } )
+     */
+    "oExclude": $.extend( {}, DataTable.models.oExclude ),
 
 
-	/**
-	 * __Deprecated__ The functionality provided by this parameter has now been
-	 * superseded by that provided through `ajax`, which should be used instead.
-	 *
-	 * You can instruct DataTables to load data from an external
-	 * source using this parameter (use aData if you want to pass data in you
-	 * already have). Simply provide a url a JSON object can be obtained from.
-	 *  @type string
-	 *  @default null
-	 *
-	 *  @dtopt Options
-	 *  @dtopt Server-side
-	 *  @name DataTable.defaults.ajaxSource
-	 *
-	 *  @deprecated 1.10. Please use `ajax` for this functionality now.
-	 */
-	"sAjaxSource": null,
+    /**
+     * __Deprecated__ The functionality provided by this parameter has now been
+     * superseded by that provided through `ajax`, which should be used instead.
+     *
+     * By default DataTables will look for the property `data` (or `aaData` for
+     * compatibility with DataTables 1.9-) when obtaining data from an Ajax
+     * source or for server-side processing - this parameter allows that
+     * property to be changed. You can use Javascript dotted object notation to
+     * get a data source for multiple levels of nesting.
+     *  @type string
+     *  @default data
+     *
+     *  @dtopt Options
+     *  @dtopt Server-side
+     *  @name DataTable.defaults.ajaxDataProp
+     *
+     *  @deprecated 1.10. Please use `ajax` for this functionality now.
+     */
+    "sAjaxDataProp": "data",
 
 
-	/**
-	 * This initialisation variable allows you to specify exactly where in the
-	 * DOM you want DataTables to inject the various controls it adds to the page
-	 * (for example you might want the pagination controls at the top of the
-	 * table). DIV elements (with or without a custom class) can also be added to
-	 * aid styling. The follow syntax is used:
-	 *   <ul>
-	 *     <li>The following options are allowed:
-	 *       <ul>
-	 *         <li>'l' - Length changing</li>
-	 *         <li>'f' - Filtering input</li>
-	 *         <li>'t' - The table!</li>
-	 *         <li>'i' - Information</li>
-	 *         <li>'p' - Pagination</li>
-	 *         <li>'r' - pRocessing</li>
-	 *       </ul>
-	 *     </li>
-	 *     <li>The following constants are allowed:
-	 *       <ul>
-	 *         <li>'H' - jQueryUI theme "header" classes ('fg-toolbar ui-widget-header ui-corner-tl ui-corner-tr ui-helper-clearfix')</li>
-	 *         <li>'F' - jQueryUI theme "footer" classes ('fg-toolbar ui-widget-header ui-corner-bl ui-corner-br ui-helper-clearfix')</li>
-	 *       </ul>
-	 *     </li>
-	 *     <li>The following syntax is expected:
-	 *       <ul>
-	 *         <li>'&lt;' and '&gt;' - div elements</li>
-	 *         <li>'&lt;"class" and '&gt;' - div with a class</li>
-	 *         <li>'&lt;"#id" and '&gt;' - div with an ID</li>
-	 *       </ul>
-	 *     </li>
-	 *     <li>Examples:
-	 *       <ul>
-	 *         <li>'&lt;"wrapper"flipt&gt;'</li>
-	 *         <li>'&lt;lf&lt;t&gt;ip&gt;'</li>
-	 *       </ul>
-	 *     </li>
-	 *   </ul>
-	 *  @type string
-	 *  @default lfrtip <i>(when `jQueryUI` is false)</i> <b>or</b>
-	 *    <"H"lfr>t<"F"ip> <i>(when `jQueryUI` is true)</i>
-	 *
-	 *  @dtopt Options
-	 *  @name DataTable.defaults.dom
-	 *
-	 *  @example
-	 *    $(document).ready( function() {
+    /**
+     * __Deprecated__ The functionality provided by this parameter has now been
+     * superseded by that provided through `ajax`, which should be used instead.
+     *
+     * You can instruct DataTables to load data from an external
+     * source using this parameter (use aData if you want to pass data in you
+     * already have). Simply provide a url a JSON object can be obtained from.
+     *  @type string
+     *  @default null
+     *
+     *  @dtopt Options
+     *  @dtopt Server-side
+     *  @name DataTable.defaults.ajaxSource
+     *
+     *  @deprecated 1.10. Please use `ajax` for this functionality now.
+     */
+    "sAjaxSource": null,
+
+
+    /**
+     * This initialisation variable allows you to specify exactly where in the
+     * DOM you want DataTables to inject the various controls it adds to the page
+     * (for example you might want the pagination controls at the top of the
+     * table). DIV elements (with or without a custom class) can also be added to
+     * aid styling. The follow syntax is used:
+     *   <ul>
+     *     <li>The following options are allowed:
+     *       <ul>
+     *         <li>'l' - Length changing</li>
+     *         <li>'f' - Filtering input</li>
+     *         <li>'t' - The table!</li>
+     *         <li>'i' - Information</li>
+     *         <li>'p' - Pagination</li>
+     *         <li>'r' - pRocessing</li>
+     *       </ul>
+     *     </li>
+     *     <li>The following constants are allowed:
+     *       <ul>
+     *         <li>'H' - jQueryUI theme "header" classes ('fg-toolbar ui-widget-header ui-corner-tl ui-corner-tr ui-helper-clearfix')</li>
+     *         <li>'F' - jQueryUI theme "footer" classes ('fg-toolbar ui-widget-header ui-corner-bl ui-corner-br ui-helper-clearfix')</li>
+     *       </ul>
+     *     </li>
+     *     <li>The following syntax is expected:
+     *       <ul>
+     *         <li>'&lt;' and '&gt;' - div elements</li>
+     *         <li>'&lt;"class" and '&gt;' - div with a class</li>
+     *         <li>'&lt;"#id" and '&gt;' - div with an ID</li>
+     *       </ul>
+     *     </li>
+     *     <li>Examples:
+     *       <ul>
+     *         <li>'&lt;"wrapper"flipt&gt;'</li>
+     *         <li>'&lt;lf&lt;t&gt;ip&gt;'</li>
+     *       </ul>
+     *     </li>
+     *   </ul>
+     *  @type string
+     *  @default lfrtip <i>(when `jQueryUI` is false)</i> <b>or</b>
+     *    <"H"lfr>t<"F"ip> <i>(when `jQueryUI` is true)</i>
+     *
+     *  @dtopt Options
+     *  @name DataTable.defaults.dom
+     *
+     *  @example
+     *    $(document).ready( function() {
 	 *      $('#example').dataTable( {
 	 *        "dom": '&lt;"top"i&gt;rt&lt;"bottom"flp&gt;&lt;"clear"&gt;'
 	 *      } );
 	 *    } );
-	 */
-	"sDom": "lfrtip",
+     */
+    "sDom": "lfrtip",
 
 
-	/**
-	 * Search delay option. This will throttle full table searches that use the
-	 * DataTables provided search input element (it does not effect calls to
-	 * `dt-api search()`, providing a delay before the search is made.
-	 *  @type integer
-	 *  @default 0
-	 *
-	 *  @dtopt Options
-	 *  @name DataTable.defaults.searchDelay
-	 *
-	 *  @example
-	 *    $(document).ready( function() {
+    /**
+     * Search delay option. This will throttle full table searches that use the
+     * DataTables provided search input element (it does not effect calls to
+     * `dt-api search()`, providing a delay before the search is made.
+     *  @type integer
+     *  @default 0
+     *
+     *  @dtopt Options
+     *  @name DataTable.defaults.searchDelay
+     *
+     *  @example
+     *    $(document).ready( function() {
 	 *      $('#example').dataTable( {
 	 *        "searchDelay": 200
 	 *      } );
 	 *    } )
-	 */
-	"searchDelay": null,
+     */
+    "searchDelay": null,
 
 
-	/**
-	 * DataTables features six different built-in options for the buttons to
-	 * display for pagination control:
-	 *
-	 * * `numbers` - Page number buttons only
-	 * * `simple` - 'Previous' and 'Next' buttons only
-	 * * 'simple_numbers` - 'Previous' and 'Next' buttons, plus page numbers
-	 * * `full` - 'First', 'Previous', 'Next' and 'Last' buttons
-	 * * `full_numbers` - 'First', 'Previous', 'Next' and 'Last' buttons, plus page numbers
-	 * * `first_last_numbers` - 'First' and 'Last' buttons, plus page numbers
-	 *  
-	 * Further methods can be added using {@link DataTable.ext.oPagination}.
-	 *  @type string
-	 *  @default simple_numbers
-	 *
-	 *  @dtopt Options
-	 *  @name DataTable.defaults.pagingType
-	 *
-	 *  @example
-	 *    $(document).ready( function() {
+    /**
+     * DataTables features six different built-in options for the buttons to
+     * display for pagination control:
+     *
+     * * `numbers` - Page number buttons only
+     * * `simple` - 'Previous' and 'Next' buttons only
+     * * 'simple_numbers` - 'Previous' and 'Next' buttons, plus page numbers
+     * * `full` - 'First', 'Previous', 'Next' and 'Last' buttons
+     * * `full_numbers` - 'First', 'Previous', 'Next' and 'Last' buttons, plus page numbers
+     * * `first_last_numbers` - 'First' and 'Last' buttons, plus page numbers
+     *
+     * Further methods can be added using {@link DataTable.ext.oPagination}.
+     *  @type string
+     *  @default simple_numbers
+     *
+     *  @dtopt Options
+     *  @name DataTable.defaults.pagingType
+     *
+     *  @example
+     *    $(document).ready( function() {
 	 *      $('#example').dataTable( {
 	 *        "pagingType": "full_numbers"
 	 *      } );
 	 *    } )
-	 */
-	"sPaginationType": "simple_numbers",
+     */
+    "sPaginationType": "simple_numbers",
 
 
-	/**
-	 * Enable horizontal scrolling. When a table is too wide to fit into a
-	 * certain layout, or you have a large number of columns in the table, you
-	 * can enable x-scrolling to show the table in a viewport, which can be
-	 * scrolled. This property can be `true` which will allow the table to
-	 * scroll horizontally when needed, or any CSS unit, or a number (in which
-	 * case it will be treated as a pixel measurement). Setting as simply `true`
-	 * is recommended.
-	 *  @type boolean|string
-	 *  @default <i>blank string - i.e. disabled</i>
-	 *
-	 *  @dtopt Features
-	 *  @name DataTable.defaults.scrollX
-	 *
-	 *  @example
-	 *    $(document).ready( function() {
+    /**
+     * Enable horizontal scrolling. When a table is too wide to fit into a
+     * certain layout, or you have a large number of columns in the table, you
+     * can enable x-scrolling to show the table in a viewport, which can be
+     * scrolled. This property can be `true` which will allow the table to
+     * scroll horizontally when needed, or any CSS unit, or a number (in which
+     * case it will be treated as a pixel measurement). Setting as simply `true`
+     * is recommended.
+     *  @type boolean|string
+     *  @default <i>blank string - i.e. disabled</i>
+     *
+     *  @dtopt Features
+     *  @name DataTable.defaults.scrollX
+     *
+     *  @example
+     *    $(document).ready( function() {
 	 *      $('#example').dataTable( {
 	 *        "scrollX": true,
 	 *        "scrollCollapse": true
 	 *      } );
 	 *    } );
-	 */
-	"sScrollX": "",
+     */
+    "sScrollX": "",
 
 
-	/**
-	 * This property can be used to force a DataTable to use more width than it
-	 * might otherwise do when x-scrolling is enabled. For example if you have a
-	 * table which requires to be well spaced, this parameter is useful for
-	 * "over-sizing" the table, and thus forcing scrolling. This property can by
-	 * any CSS unit, or a number (in which case it will be treated as a pixel
-	 * measurement).
-	 *  @type string
-	 *  @default <i>blank string - i.e. disabled</i>
-	 *
-	 *  @dtopt Options
-	 *  @name DataTable.defaults.scrollXInner
-	 *
-	 *  @example
-	 *    $(document).ready( function() {
+    /**
+     * This property can be used to force a DataTable to use more width than it
+     * might otherwise do when x-scrolling is enabled. For example if you have a
+     * table which requires to be well spaced, this parameter is useful for
+     * "over-sizing" the table, and thus forcing scrolling. This property can by
+     * any CSS unit, or a number (in which case it will be treated as a pixel
+     * measurement).
+     *  @type string
+     *  @default <i>blank string - i.e. disabled</i>
+     *
+     *  @dtopt Options
+     *  @name DataTable.defaults.scrollXInner
+     *
+     *  @example
+     *    $(document).ready( function() {
 	 *      $('#example').dataTable( {
 	 *        "scrollX": "100%",
 	 *        "scrollXInner": "110%"
 	 *      } );
 	 *    } );
-	 */
-	"sScrollXInner": "",
+     */
+    "sScrollXInner": "",
 
 
-	/**
-	 * Enable vertical scrolling. Vertical scrolling will constrain the DataTable
-	 * to the given height, and enable scrolling for any data which overflows the
-	 * current viewport. This can be used as an alternative to paging to display
-	 * a lot of data in a small area (although paging and scrolling can both be
-	 * enabled at the same time). This property can be any CSS unit, or a number
-	 * (in which case it will be treated as a pixel measurement).
-	 *  @type string
-	 *  @default <i>blank string - i.e. disabled</i>
-	 *
-	 *  @dtopt Features
-	 *  @name DataTable.defaults.scrollY
-	 *
-	 *  @example
-	 *    $(document).ready( function() {
+    /**
+     * Enable vertical scrolling. Vertical scrolling will constrain the DataTable
+     * to the given height, and enable scrolling for any data which overflows the
+     * current viewport. This can be used as an alternative to paging to display
+     * a lot of data in a small area (although paging and scrolling can both be
+     * enabled at the same time). This property can be any CSS unit, or a number
+     * (in which case it will be treated as a pixel measurement).
+     *  @type string
+     *  @default <i>blank string - i.e. disabled</i>
+     *
+     *  @dtopt Features
+     *  @name DataTable.defaults.scrollY
+     *
+     *  @example
+     *    $(document).ready( function() {
 	 *      $('#example').dataTable( {
 	 *        "scrollY": "200px",
 	 *        "paginate": false
 	 *      } );
 	 *    } );
-	 */
-	"sScrollY": "",
+     */
+    "sScrollY": "",
 
 
-	/**
-	 * __Deprecated__ The functionality provided by this parameter has now been
-	 * superseded by that provided through `ajax`, which should be used instead.
-	 *
-	 * Set the HTTP method that is used to make the Ajax call for server-side
-	 * processing or Ajax sourced data.
-	 *  @type string
-	 *  @default GET
-	 *
-	 *  @dtopt Options
-	 *  @dtopt Server-side
-	 *  @name DataTable.defaults.serverMethod
-	 *
-	 *  @deprecated 1.10. Please use `ajax` for this functionality now.
-	 */
-	"sServerMethod": "GET",
+    /**
+     * __Deprecated__ The functionality provided by this parameter has now been
+     * superseded by that provided through `ajax`, which should be used instead.
+     *
+     * Set the HTTP method that is used to make the Ajax call for server-side
+     * processing or Ajax sourced data.
+     *  @type string
+     *  @default GET
+     *
+     *  @dtopt Options
+     *  @dtopt Server-side
+     *  @name DataTable.defaults.serverMethod
+     *
+     *  @deprecated 1.10. Please use `ajax` for this functionality now.
+     */
+    "sServerMethod": "GET",
 
 
-	/**
-	 * DataTables makes use of renderers when displaying HTML elements for
-	 * a table. These renderers can be added or modified by plug-ins to
-	 * generate suitable mark-up for a site. For example the Bootstrap
-	 * integration plug-in for DataTables uses a paging button renderer to
-	 * display pagination buttons in the mark-up required by Bootstrap.
-	 *
-	 * For further information about the renderers available see
-	 * DataTable.ext.renderer
-	 *  @type string|object
-	 *  @default null
-	 *
-	 *  @name DataTable.defaults.renderer
-	 *
-	 */
-	"renderer": null,
+    /**
+     * DataTables makes use of renderers when displaying HTML elements for
+     * a table. These renderers can be added or modified by plug-ins to
+     * generate suitable mark-up for a site. For example the Bootstrap
+     * integration plug-in for DataTables uses a paging button renderer to
+     * display pagination buttons in the mark-up required by Bootstrap.
+     *
+     * For further information about the renderers available see
+     * DataTable.ext.renderer
+     *  @type string|object
+     *  @default null
+     *
+     *  @name DataTable.defaults.renderer
+     *
+     */
+    "renderer": null,
 
 
-	/**
-	 * Set the data property name that DataTables should use to get a row's id
-	 * to set as the `id` property in the node.
-	 *  @type string
-	 *  @default DT_RowId
-	 *
-	 *  @name DataTable.defaults.rowId
-	 */
-	"rowId": "DT_RowId"
+    /**
+     * Set the data property name that DataTables should use to get a row's id
+     * to set as the `id` property in the node.
+     *  @type string
+     *  @default DT_RowId
+     *
+     *  @name DataTable.defaults.rowId
+     */
+    "rowId": "DT_RowId"
 };
 
 _fnHungarianMap( DataTable.defaults );

--- a/js/model/model.exclude.js
+++ b/js/model/model.exclude.js
@@ -1,0 +1,40 @@
+
+
+
+/**
+ * Template object for the way in which DataTables holds information about
+ * search information for the global filter and individual column filters.
+ *  @namespace
+ */
+DataTable.models.oExclude = {
+    /**
+     * Flag to indicate if the filtering should be case insensitive or not
+     *  @type boolean
+     *  @default true
+     */
+    "bCaseInsensitive": true,
+
+    /**
+     * Applied search term
+     *  @type string
+     *  @default <i>Empty string</i>
+     */
+    "sSearch": "",
+
+    /**
+     * Flag to indicate if the search term should be interpreted as a
+     * regular expression (true) or not (false) and therefore and special
+     * regex characters escaped.
+     *  @type boolean
+     *  @default false
+     */
+    "bRegex": false,
+
+    /**
+     * Flag to indicate if DataTables is to use its smart filtering or not.
+     *  @type boolean
+     *  @default true
+     */
+    "bSmart": true
+};
+

--- a/js/model/model.settings.js
+++ b/js/model/model.settings.js
@@ -23,897 +23,928 @@
  *    will be done in 2.0.
  */
 DataTable.models.oSettings = {
-	/**
-	 * Primary features of DataTables and their enablement state.
-	 *  @namespace
-	 */
-	"oFeatures": {
-
-		/**
-		 * Flag to say if DataTables should automatically try to calculate the
-		 * optimum table and columns widths (true) or not (false).
-		 * Note that this parameter will be set by the initialisation routine. To
-		 * set a default use {@link DataTable.defaults}.
-		 *  @type boolean
-		 */
-		"bAutoWidth": null,
-
-		/**
-		 * Delay the creation of TR and TD elements until they are actually
-		 * needed by a driven page draw. This can give a significant speed
-		 * increase for Ajax source and Javascript source data, but makes no
-		 * difference at all fro DOM and server-side processing tables.
-		 * Note that this parameter will be set by the initialisation routine. To
-		 * set a default use {@link DataTable.defaults}.
-		 *  @type boolean
-		 */
-		"bDeferRender": null,
-
-		/**
-		 * Enable filtering on the table or not. Note that if this is disabled
-		 * then there is no filtering at all on the table, including fnFilter.
-		 * To just remove the filtering input use sDom and remove the 'f' option.
-		 * Note that this parameter will be set by the initialisation routine. To
-		 * set a default use {@link DataTable.defaults}.
-		 *  @type boolean
-		 */
-		"bFilter": null,
-
-		/**
-		 * Table information element (the 'Showing x of y records' div) enable
-		 * flag.
-		 * Note that this parameter will be set by the initialisation routine. To
-		 * set a default use {@link DataTable.defaults}.
-		 *  @type boolean
-		 */
-		"bInfo": null,
-
-		/**
-		 * Present a user control allowing the end user to change the page size
-		 * when pagination is enabled.
-		 * Note that this parameter will be set by the initialisation routine. To
-		 * set a default use {@link DataTable.defaults}.
-		 *  @type boolean
-		 */
-		"bLengthChange": null,
-
-		/**
-		 * Pagination enabled or not. Note that if this is disabled then length
-		 * changing must also be disabled.
-		 * Note that this parameter will be set by the initialisation routine. To
-		 * set a default use {@link DataTable.defaults}.
-		 *  @type boolean
-		 */
-		"bPaginate": null,
-
-		/**
-		 * Processing indicator enable flag whenever DataTables is enacting a
-		 * user request - typically an Ajax request for server-side processing.
-		 * Note that this parameter will be set by the initialisation routine. To
-		 * set a default use {@link DataTable.defaults}.
-		 *  @type boolean
-		 */
-		"bProcessing": null,
-
-		/**
-		 * Server-side processing enabled flag - when enabled DataTables will
-		 * get all data from the server for every draw - there is no filtering,
-		 * sorting or paging done on the client-side.
-		 * Note that this parameter will be set by the initialisation routine. To
-		 * set a default use {@link DataTable.defaults}.
-		 *  @type boolean
-		 */
-		"bServerSide": null,
-
-		/**
-		 * Sorting enablement flag.
-		 * Note that this parameter will be set by the initialisation routine. To
-		 * set a default use {@link DataTable.defaults}.
-		 *  @type boolean
-		 */
-		"bSort": null,
-
-		/**
-		 * Multi-column sorting
-		 * Note that this parameter will be set by the initialisation routine. To
-		 * set a default use {@link DataTable.defaults}.
-		 *  @type boolean
-		 */
-		"bSortMulti": null,
-
-		/**
-		 * Apply a class to the columns which are being sorted to provide a
-		 * visual highlight or not. This can slow things down when enabled since
-		 * there is a lot of DOM interaction.
-		 * Note that this parameter will be set by the initialisation routine. To
-		 * set a default use {@link DataTable.defaults}.
-		 *  @type boolean
-		 */
-		"bSortClasses": null,
-
-		/**
-		 * State saving enablement flag.
-		 * Note that this parameter will be set by the initialisation routine. To
-		 * set a default use {@link DataTable.defaults}.
-		 *  @type boolean
-		 */
-		"bStateSave": null
-	},
-
-
-	/**
-	 * Scrolling settings for a table.
-	 *  @namespace
-	 */
-	"oScroll": {
-		/**
-		 * When the table is shorter in height than sScrollY, collapse the
-		 * table container down to the height of the table (when true).
-		 * Note that this parameter will be set by the initialisation routine. To
-		 * set a default use {@link DataTable.defaults}.
-		 *  @type boolean
-		 */
-		"bCollapse": null,
-
-		/**
-		 * Width of the scrollbar for the web-browser's platform. Calculated
-		 * during table initialisation.
-		 *  @type int
-		 *  @default 0
-		 */
-		"iBarWidth": 0,
-
-		/**
-		 * Viewport width for horizontal scrolling. Horizontal scrolling is
-		 * disabled if an empty string.
-		 * Note that this parameter will be set by the initialisation routine. To
-		 * set a default use {@link DataTable.defaults}.
-		 *  @type string
-		 */
-		"sX": null,
-
-		/**
-		 * Width to expand the table to when using x-scrolling. Typically you
-		 * should not need to use this.
-		 * Note that this parameter will be set by the initialisation routine. To
-		 * set a default use {@link DataTable.defaults}.
-		 *  @type string
-		 *  @deprecated
-		 */
-		"sXInner": null,
-
-		/**
-		 * Viewport height for vertical scrolling. Vertical scrolling is disabled
-		 * if an empty string.
-		 * Note that this parameter will be set by the initialisation routine. To
-		 * set a default use {@link DataTable.defaults}.
-		 *  @type string
-		 */
-		"sY": null
-	},
-
-	/**
-	 * Language information for the table.
-	 *  @namespace
-	 *  @extends DataTable.defaults.oLanguage
-	 */
-	"oLanguage": {
-		/**
-		 * Information callback function. See
-		 * {@link DataTable.defaults.fnInfoCallback}
-		 *  @type function
-		 *  @default null
-		 */
-		"fnInfoCallback": null
-	},
-
-	/**
-	 * Browser support parameters
-	 *  @namespace
-	 */
-	"oBrowser": {
-		/**
-		 * Indicate if the browser incorrectly calculates width:100% inside a
-		 * scrolling element (IE6/7)
-		 *  @type boolean
-		 *  @default false
-		 */
-		"bScrollOversize": false,
-
-		/**
-		 * Determine if the vertical scrollbar is on the right or left of the
-		 * scrolling container - needed for rtl language layout, although not
-		 * all browsers move the scrollbar (Safari).
-		 *  @type boolean
-		 *  @default false
-		 */
-		"bScrollbarLeft": false,
-
-		/**
-		 * Flag for if `getBoundingClientRect` is fully supported or not
-		 *  @type boolean
-		 *  @default false
-		 */
-		"bBounding": false,
-
-		/**
-		 * Browser scrollbar width
-		 *  @type integer
-		 *  @default 0
-		 */
-		"barWidth": 0
-	},
-
-
-	"ajax": null,
-
-
-	/**
-	 * Array referencing the nodes which are used for the features. The
-	 * parameters of this object match what is allowed by sDom - i.e.
-	 *   <ul>
-	 *     <li>'l' - Length changing</li>
-	 *     <li>'f' - Filtering input</li>
-	 *     <li>'t' - The table!</li>
-	 *     <li>'i' - Information</li>
-	 *     <li>'p' - Pagination</li>
-	 *     <li>'r' - pRocessing</li>
-	 *   </ul>
-	 *  @type array
-	 *  @default []
-	 */
-	"aanFeatures": [],
-
-	/**
-	 * Store data information - see {@link DataTable.models.oRow} for detailed
-	 * information.
-	 *  @type array
-	 *  @default []
-	 */
-	"aoData": [],
-
-	/**
-	 * Array of indexes which are in the current display (after filtering etc)
-	 *  @type array
-	 *  @default []
-	 */
-	"aiDisplay": [],
-
-	/**
-	 * Array of indexes for display - no filtering
-	 *  @type array
-	 *  @default []
-	 */
-	"aiDisplayMaster": [],
-
-	/**
-	 * Map of row ids to data indexes
-	 *  @type object
-	 *  @default {}
-	 */
-	"aIds": {},
-
-	/**
-	 * Store information about each column that is in use
-	 *  @type array
-	 *  @default []
-	 */
-	"aoColumns": [],
-
-	/**
-	 * Store information about the table's header
-	 *  @type array
-	 *  @default []
-	 */
-	"aoHeader": [],
-
-	/**
-	 * Store information about the table's footer
-	 *  @type array
-	 *  @default []
-	 */
-	"aoFooter": [],
-
-	/**
-	 * Store the applied global search information in case we want to force a
-	 * research or compare the old search to a new one.
-	 * Note that this parameter will be set by the initialisation routine. To
-	 * set a default use {@link DataTable.defaults}.
-	 *  @namespace
-	 *  @extends DataTable.models.oSearch
-	 */
-	"oPreviousSearch": {},
-
-	/**
-	 * Store the applied search for each column - see
-	 * {@link DataTable.models.oSearch} for the format that is used for the
-	 * filtering information for each column.
-	 *  @type array
-	 *  @default []
-	 */
-	"aoPreSearchCols": [],
-
-	/**
-	 * Sorting that is applied to the table. Note that the inner arrays are
-	 * used in the following manner:
-	 * <ul>
-	 *   <li>Index 0 - column number</li>
-	 *   <li>Index 1 - current sorting direction</li>
-	 * </ul>
-	 * Note that this parameter will be set by the initialisation routine. To
-	 * set a default use {@link DataTable.defaults}.
-	 *  @type array
-	 *  @todo These inner arrays should really be objects
-	 */
-	"aaSorting": null,
-
-	/**
-	 * Sorting that is always applied to the table (i.e. prefixed in front of
-	 * aaSorting).
-	 * Note that this parameter will be set by the initialisation routine. To
-	 * set a default use {@link DataTable.defaults}.
-	 *  @type array
-	 *  @default []
-	 */
-	"aaSortingFixed": [],
-
-	/**
-	 * Classes to use for the striping of a table.
-	 * Note that this parameter will be set by the initialisation routine. To
-	 * set a default use {@link DataTable.defaults}.
-	 *  @type array
-	 *  @default []
-	 */
-	"asStripeClasses": null,
-
-	/**
-	 * If restoring a table - we should restore its striping classes as well
-	 *  @type array
-	 *  @default []
-	 */
-	"asDestroyStripes": [],
-
-	/**
-	 * If restoring a table - we should restore its width
-	 *  @type int
-	 *  @default 0
-	 */
-	"sDestroyWidth": 0,
-
-	/**
-	 * Callback functions array for every time a row is inserted (i.e. on a draw).
-	 *  @type array
-	 *  @default []
-	 */
-	"aoRowCallback": [],
-
-	/**
-	 * Callback functions for the header on each draw.
-	 *  @type array
-	 *  @default []
-	 */
-	"aoHeaderCallback": [],
-
-	/**
-	 * Callback function for the footer on each draw.
-	 *  @type array
-	 *  @default []
-	 */
-	"aoFooterCallback": [],
-
-	/**
-	 * Array of callback functions for draw callback functions
-	 *  @type array
-	 *  @default []
-	 */
-	"aoDrawCallback": [],
-
-	/**
-	 * Array of callback functions for row created function
-	 *  @type array
-	 *  @default []
-	 */
-	"aoRowCreatedCallback": [],
-
-	/**
-	 * Callback functions for just before the table is redrawn. A return of
-	 * false will be used to cancel the draw.
-	 *  @type array
-	 *  @default []
-	 */
-	"aoPreDrawCallback": [],
-
-	/**
-	 * Callback functions for when the table has been initialised.
-	 *  @type array
-	 *  @default []
-	 */
-	"aoInitComplete": [],
-
-
-	/**
-	 * Callbacks for modifying the settings to be stored for state saving, prior to
-	 * saving state.
-	 *  @type array
-	 *  @default []
-	 */
-	"aoStateSaveParams": [],
-
-	/**
-	 * Callbacks for modifying the settings that have been stored for state saving
-	 * prior to using the stored values to restore the state.
-	 *  @type array
-	 *  @default []
-	 */
-	"aoStateLoadParams": [],
-
-	/**
-	 * Callbacks for operating on the settings object once the saved state has been
-	 * loaded
-	 *  @type array
-	 *  @default []
-	 */
-	"aoStateLoaded": [],
-
-	/**
-	 * Cache the table ID for quick access
-	 *  @type string
-	 *  @default <i>Empty string</i>
-	 */
-	"sTableId": "",
-
-	/**
-	 * The TABLE node for the main table
-	 *  @type node
-	 *  @default null
-	 */
-	"nTable": null,
-
-	/**
-	 * Permanent ref to the thead element
-	 *  @type node
-	 *  @default null
-	 */
-	"nTHead": null,
-
-	/**
-	 * Permanent ref to the tfoot element - if it exists
-	 *  @type node
-	 *  @default null
-	 */
-	"nTFoot": null,
-
-	/**
-	 * Permanent ref to the tbody element
-	 *  @type node
-	 *  @default null
-	 */
-	"nTBody": null,
-
-	/**
-	 * Cache the wrapper node (contains all DataTables controlled elements)
-	 *  @type node
-	 *  @default null
-	 */
-	"nTableWrapper": null,
-
-	/**
-	 * Indicate if when using server-side processing the loading of data
-	 * should be deferred until the second draw.
-	 * Note that this parameter will be set by the initialisation routine. To
-	 * set a default use {@link DataTable.defaults}.
-	 *  @type boolean
-	 *  @default false
-	 */
-	"bDeferLoading": false,
-
-	/**
-	 * Indicate if all required information has been read in
-	 *  @type boolean
-	 *  @default false
-	 */
-	"bInitialised": false,
-
-	/**
-	 * Information about open rows. Each object in the array has the parameters
-	 * 'nTr' and 'nParent'
-	 *  @type array
-	 *  @default []
-	 */
-	"aoOpenRows": [],
-
-	/**
-	 * Dictate the positioning of DataTables' control elements - see
-	 * {@link DataTable.model.oInit.sDom}.
-	 * Note that this parameter will be set by the initialisation routine. To
-	 * set a default use {@link DataTable.defaults}.
-	 *  @type string
-	 *  @default null
-	 */
-	"sDom": null,
-
-	/**
-	 * Search delay (in mS)
-	 *  @type integer
-	 *  @default null
-	 */
-	"searchDelay": null,
-
-	/**
-	 * Which type of pagination should be used.
-	 * Note that this parameter will be set by the initialisation routine. To
-	 * set a default use {@link DataTable.defaults}.
-	 *  @type string
-	 *  @default two_button
-	 */
-	"sPaginationType": "two_button",
-
-	/**
-	 * The state duration (for `stateSave`) in seconds.
-	 * Note that this parameter will be set by the initialisation routine. To
-	 * set a default use {@link DataTable.defaults}.
-	 *  @type int
-	 *  @default 0
-	 */
-	"iStateDuration": 0,
-
-	/**
-	 * Array of callback functions for state saving. Each array element is an
-	 * object with the following parameters:
-	 *   <ul>
-	 *     <li>function:fn - function to call. Takes two parameters, oSettings
-	 *       and the JSON string to save that has been thus far created. Returns
-	 *       a JSON string to be inserted into a json object
-	 *       (i.e. '"param": [ 0, 1, 2]')</li>
-	 *     <li>string:sName - name of callback</li>
-	 *   </ul>
-	 *  @type array
-	 *  @default []
-	 */
-	"aoStateSave": [],
-
-	/**
-	 * Array of callback functions for state loading. Each array element is an
-	 * object with the following parameters:
-	 *   <ul>
-	 *     <li>function:fn - function to call. Takes two parameters, oSettings
-	 *       and the object stored. May return false to cancel state loading</li>
-	 *     <li>string:sName - name of callback</li>
-	 *   </ul>
-	 *  @type array
-	 *  @default []
-	 */
-	"aoStateLoad": [],
-
-	/**
-	 * State that was saved. Useful for back reference
-	 *  @type object
-	 *  @default null
-	 */
-	"oSavedState": null,
-
-	/**
-	 * State that was loaded. Useful for back reference
-	 *  @type object
-	 *  @default null
-	 */
-	"oLoadedState": null,
-
-	/**
-	 * Source url for AJAX data for the table.
-	 * Note that this parameter will be set by the initialisation routine. To
-	 * set a default use {@link DataTable.defaults}.
-	 *  @type string
-	 *  @default null
-	 */
-	"sAjaxSource": null,
-
-	/**
-	 * Property from a given object from which to read the table data from. This
-	 * can be an empty string (when not server-side processing), in which case
-	 * it is  assumed an an array is given directly.
-	 * Note that this parameter will be set by the initialisation routine. To
-	 * set a default use {@link DataTable.defaults}.
-	 *  @type string
-	 */
-	"sAjaxDataProp": null,
-
-	/**
-	 * Note if draw should be blocked while getting data
-	 *  @type boolean
-	 *  @default true
-	 */
-	"bAjaxDataGet": true,
-
-	/**
-	 * The last jQuery XHR object that was used for server-side data gathering.
-	 * This can be used for working with the XHR information in one of the
-	 * callbacks
-	 *  @type object
-	 *  @default null
-	 */
-	"jqXHR": null,
-
-	/**
-	 * JSON returned from the server in the last Ajax request
-	 *  @type object
-	 *  @default undefined
-	 */
-	"json": undefined,
-
-	/**
-	 * Data submitted as part of the last Ajax request
-	 *  @type object
-	 *  @default undefined
-	 */
-	"oAjaxData": undefined,
-
-	/**
-	 * Function to get the server-side data.
-	 * Note that this parameter will be set by the initialisation routine. To
-	 * set a default use {@link DataTable.defaults}.
-	 *  @type function
-	 */
-	"fnServerData": null,
-
-	/**
-	 * Functions which are called prior to sending an Ajax request so extra
-	 * parameters can easily be sent to the server
-	 *  @type array
-	 *  @default []
-	 */
-	"aoServerParams": [],
-
-	/**
-	 * Send the XHR HTTP method - GET or POST (could be PUT or DELETE if
-	 * required).
-	 * Note that this parameter will be set by the initialisation routine. To
-	 * set a default use {@link DataTable.defaults}.
-	 *  @type string
-	 */
-	"sServerMethod": null,
-
-	/**
-	 * Format numbers for display.
-	 * Note that this parameter will be set by the initialisation routine. To
-	 * set a default use {@link DataTable.defaults}.
-	 *  @type function
-	 */
-	"fnFormatNumber": null,
-
-	/**
-	 * List of options that can be used for the user selectable length menu.
-	 * Note that this parameter will be set by the initialisation routine. To
-	 * set a default use {@link DataTable.defaults}.
-	 *  @type array
-	 *  @default []
-	 */
-	"aLengthMenu": null,
-
-	/**
-	 * Counter for the draws that the table does. Also used as a tracker for
-	 * server-side processing
-	 *  @type int
-	 *  @default 0
-	 */
-	"iDraw": 0,
-
-	/**
-	 * Indicate if a redraw is being done - useful for Ajax
-	 *  @type boolean
-	 *  @default false
-	 */
-	"bDrawing": false,
-
-	/**
-	 * Draw index (iDraw) of the last error when parsing the returned data
-	 *  @type int
-	 *  @default -1
-	 */
-	"iDrawError": -1,
-
-	/**
-	 * Paging display length
-	 *  @type int
-	 *  @default 10
-	 */
-	"_iDisplayLength": 10,
-
-	/**
-	 * Paging start point - aiDisplay index
-	 *  @type int
-	 *  @default 0
-	 */
-	"_iDisplayStart": 0,
-
-	/**
-	 * Server-side processing - number of records in the result set
-	 * (i.e. before filtering), Use fnRecordsTotal rather than
-	 * this property to get the value of the number of records, regardless of
-	 * the server-side processing setting.
-	 *  @type int
-	 *  @default 0
-	 *  @private
-	 */
-	"_iRecordsTotal": 0,
-
-	/**
-	 * Server-side processing - number of records in the current display set
-	 * (i.e. after filtering). Use fnRecordsDisplay rather than
-	 * this property to get the value of the number of records, regardless of
-	 * the server-side processing setting.
-	 *  @type boolean
-	 *  @default 0
-	 *  @private
-	 */
-	"_iRecordsDisplay": 0,
-
-	/**
-	 * Flag to indicate if jQuery UI marking and classes should be used.
-	 * Note that this parameter will be set by the initialisation routine. To
-	 * set a default use {@link DataTable.defaults}.
-	 *  @type boolean
-	 */
-	"bJUI": null,
-
-	/**
-	 * The classes to use for the table
-	 *  @type object
-	 *  @default {}
-	 */
-	"oClasses": {},
-
-	/**
-	 * Flag attached to the settings object so you can check in the draw
-	 * callback if filtering has been done in the draw. Deprecated in favour of
-	 * events.
-	 *  @type boolean
-	 *  @default false
-	 *  @deprecated
-	 */
-	"bFiltered": false,
-
-	/**
-	 * Flag attached to the settings object so you can check in the draw
-	 * callback if sorting has been done in the draw. Deprecated in favour of
-	 * events.
-	 *  @type boolean
-	 *  @default false
-	 *  @deprecated
-	 */
-	"bSorted": false,
-
-	/**
-	 * Indicate that if multiple rows are in the header and there is more than
-	 * one unique cell per column, if the top one (true) or bottom one (false)
-	 * should be used for sorting / title by DataTables.
-	 * Note that this parameter will be set by the initialisation routine. To
-	 * set a default use {@link DataTable.defaults}.
-	 *  @type boolean
-	 */
-	"bSortCellsTop": null,
-
-	/**
-	 * Initialisation object that is used for the table
-	 *  @type object
-	 *  @default null
-	 */
-	"oInit": null,
-
-	/**
-	 * Destroy callback functions - for plug-ins to attach themselves to the
-	 * destroy so they can clean up markup and events.
-	 *  @type array
-	 *  @default []
-	 */
-	"aoDestroyCallback": [],
-
-
-	/**
-	 * Get the number of records in the current record set, before filtering
-	 *  @type function
-	 */
-	"fnRecordsTotal": function ()
-	{
-		return _fnDataSource( this ) == 'ssp' ?
-			this._iRecordsTotal * 1 :
-			this.aiDisplayMaster.length;
-	},
-
-	/**
-	 * Get the number of records in the current record set, after filtering
-	 *  @type function
-	 */
-	"fnRecordsDisplay": function ()
-	{
-		return _fnDataSource( this ) == 'ssp' ?
-			this._iRecordsDisplay * 1 :
-			this.aiDisplay.length;
-	},
-
-	/**
-	 * Get the display end point - aiDisplay index
-	 *  @type function
-	 */
-	"fnDisplayEnd": function ()
-	{
-		var
-			len      = this._iDisplayLength,
-			start    = this._iDisplayStart,
-			calc     = start + len,
-			records  = this.aiDisplay.length,
-			features = this.oFeatures,
-			paginate = features.bPaginate;
-
-		if ( features.bServerSide ) {
-			return paginate === false || len === -1 ?
-				start + records :
-				Math.min( start+len, this._iRecordsDisplay );
-		}
-		else {
-			return ! paginate || calc>records || len===-1 ?
-				records :
-				calc;
-		}
-	},
-
-	/**
-	 * The DataTables object for this table
-	 *  @type object
-	 *  @default null
-	 */
-	"oInstance": null,
-
-	/**
-	 * Unique identifier for each instance of the DataTables object. If there
-	 * is an ID on the table node, then it takes that value, otherwise an
-	 * incrementing internal counter is used.
-	 *  @type string
-	 *  @default null
-	 */
-	"sInstance": null,
-
-	/**
-	 * tabindex attribute value that is added to DataTables control elements, allowing
-	 * keyboard navigation of the table and its controls.
-	 */
-	"iTabIndex": 0,
-
-	/**
-	 * DIV container for the footer scrolling table if scrolling
-	 */
-	"nScrollHead": null,
-
-	/**
-	 * DIV container for the footer scrolling table if scrolling
-	 */
-	"nScrollFoot": null,
-
-	/**
-	 * Last applied sort
-	 *  @type array
-	 *  @default []
-	 */
-	"aLastSort": [],
-
-	/**
-	 * Stored plug-in instances
-	 *  @type object
-	 *  @default {}
-	 */
-	"oPlugins": {},
-
-	/**
-	 * Function used to get a row's id from the row's data
-	 *  @type function
-	 *  @default null
-	 */
-	"rowIdFn": null,
-
-	/**
-	 * Data location where to store a row's id
-	 *  @type string
-	 *  @default null
-	 */
-	"rowId": null
+    /**
+     * Primary features of DataTables and their enablement state.
+     *  @namespace
+     */
+    "oFeatures": {
+
+        /**
+         * Flag to say if DataTables should automatically try to calculate the
+         * optimum table and columns widths (true) or not (false).
+         * Note that this parameter will be set by the initialisation routine. To
+         * set a default use {@link DataTable.defaults}.
+         *  @type boolean
+         */
+        "bAutoWidth": null,
+
+        /**
+         * Delay the creation of TR and TD elements until they are actually
+         * needed by a driven page draw. This can give a significant speed
+         * increase for Ajax source and Javascript source data, but makes no
+         * difference at all fro DOM and server-side processing tables.
+         * Note that this parameter will be set by the initialisation routine. To
+         * set a default use {@link DataTable.defaults}.
+         *  @type boolean
+         */
+        "bDeferRender": null,
+
+        /**
+         * Enable filtering on the table or not. Note that if this is disabled
+         * then there is no filtering at all on the table, including fnFilter.
+         * To just remove the filtering input use sDom and remove the 'f' option.
+         * Note that this parameter will be set by the initialisation routine. To
+         * set a default use {@link DataTable.defaults}.
+         *  @type boolean
+         */
+        "bFilter": null,
+
+        /**
+         * Enable exclude filtering on the table or not. Note that if this is disabled
+         * then there is no filtering at all on the table, including fnExclude.
+         * To just remove the filtering input use sDom and remove the 'e' option.
+         * Note that this parameter will be set by the initialisation routine. To
+         * set a default use {@link DataTable.defaults}.
+         *  @type boolean
+         */
+        "bExclude": null,
+
+        /**
+         * Table information element (the 'Showing x of y records' div) enable
+         * flag.
+         * Note that this parameter will be set by the initialisation routine. To
+         * set a default use {@link DataTable.defaults}.
+         *  @type boolean
+         */
+        "bInfo": null,
+
+        /**
+         * Present a user control allowing the end user to change the page size
+         * when pagination is enabled.
+         * Note that this parameter will be set by the initialisation routine. To
+         * set a default use {@link DataTable.defaults}.
+         *  @type boolean
+         */
+        "bLengthChange": null,
+
+        /**
+         * Pagination enabled or not. Note that if this is disabled then length
+         * changing must also be disabled.
+         * Note that this parameter will be set by the initialisation routine. To
+         * set a default use {@link DataTable.defaults}.
+         *  @type boolean
+         */
+        "bPaginate": null,
+
+        /**
+         * Processing indicator enable flag whenever DataTables is enacting a
+         * user request - typically an Ajax request for server-side processing.
+         * Note that this parameter will be set by the initialisation routine. To
+         * set a default use {@link DataTable.defaults}.
+         *  @type boolean
+         */
+        "bProcessing": null,
+
+        /**
+         * Server-side processing enabled flag - when enabled DataTables will
+         * get all data from the server for every draw - there is no filtering,
+         * sorting or paging done on the client-side.
+         * Note that this parameter will be set by the initialisation routine. To
+         * set a default use {@link DataTable.defaults}.
+         *  @type boolean
+         */
+        "bServerSide": null,
+
+        /**
+         * Sorting enablement flag.
+         * Note that this parameter will be set by the initialisation routine. To
+         * set a default use {@link DataTable.defaults}.
+         *  @type boolean
+         */
+        "bSort": null,
+
+        /**
+         * Multi-column sorting
+         * Note that this parameter will be set by the initialisation routine. To
+         * set a default use {@link DataTable.defaults}.
+         *  @type boolean
+         */
+        "bSortMulti": null,
+
+        /**
+         * Apply a class to the columns which are being sorted to provide a
+         * visual highlight or not. This can slow things down when enabled since
+         * there is a lot of DOM interaction.
+         * Note that this parameter will be set by the initialisation routine. To
+         * set a default use {@link DataTable.defaults}.
+         *  @type boolean
+         */
+        "bSortClasses": null,
+
+        /**
+         * State saving enablement flag.
+         * Note that this parameter will be set by the initialisation routine. To
+         * set a default use {@link DataTable.defaults}.
+         *  @type boolean
+         */
+        "bStateSave": null
+    },
+
+
+    /**
+     * Scrolling settings for a table.
+     *  @namespace
+     */
+    "oScroll": {
+        /**
+         * When the table is shorter in height than sScrollY, collapse the
+         * table container down to the height of the table (when true).
+         * Note that this parameter will be set by the initialisation routine. To
+         * set a default use {@link DataTable.defaults}.
+         *  @type boolean
+         */
+        "bCollapse": null,
+
+        /**
+         * Width of the scrollbar for the web-browser's platform. Calculated
+         * during table initialisation.
+         *  @type int
+         *  @default 0
+         */
+        "iBarWidth": 0,
+
+        /**
+         * Viewport width for horizontal scrolling. Horizontal scrolling is
+         * disabled if an empty string.
+         * Note that this parameter will be set by the initialisation routine. To
+         * set a default use {@link DataTable.defaults}.
+         *  @type string
+         */
+        "sX": null,
+
+        /**
+         * Width to expand the table to when using x-scrolling. Typically you
+         * should not need to use this.
+         * Note that this parameter will be set by the initialisation routine. To
+         * set a default use {@link DataTable.defaults}.
+         *  @type string
+         *  @deprecated
+         */
+        "sXInner": null,
+
+        /**
+         * Viewport height for vertical scrolling. Vertical scrolling is disabled
+         * if an empty string.
+         * Note that this parameter will be set by the initialisation routine. To
+         * set a default use {@link DataTable.defaults}.
+         *  @type string
+         */
+        "sY": null
+    },
+
+    /**
+     * Language information for the table.
+     *  @namespace
+     *  @extends DataTable.defaults.oLanguage
+     */
+    "oLanguage": {
+        /**
+         * Information callback function. See
+         * {@link DataTable.defaults.fnInfoCallback}
+         *  @type function
+         *  @default null
+         */
+        "fnInfoCallback": null
+    },
+
+    /**
+     * Browser support parameters
+     *  @namespace
+     */
+    "oBrowser": {
+        /**
+         * Indicate if the browser incorrectly calculates width:100% inside a
+         * scrolling element (IE6/7)
+         *  @type boolean
+         *  @default false
+         */
+        "bScrollOversize": false,
+
+        /**
+         * Determine if the vertical scrollbar is on the right or left of the
+         * scrolling container - needed for rtl language layout, although not
+         * all browsers move the scrollbar (Safari).
+         *  @type boolean
+         *  @default false
+         */
+        "bScrollbarLeft": false,
+
+        /**
+         * Flag for if `getBoundingClientRect` is fully supported or not
+         *  @type boolean
+         *  @default false
+         */
+        "bBounding": false,
+
+        /**
+         * Browser scrollbar width
+         *  @type integer
+         *  @default 0
+         */
+        "barWidth": 0
+    },
+
+
+    "ajax": null,
+
+
+    /**
+     * Array referencing the nodes which are used for the features. The
+     * parameters of this object match what is allowed by sDom - i.e.
+     *   <ul>
+     *     <li>'l' - Length changing</li>
+     *     <li>'f' - Filtering input</li>
+     *     <li>'e' - Exclude filtering input</li>
+     *     <li>'t' - The table!</li>
+     *     <li>'i' - Information</li>
+     *     <li>'p' - Pagination</li>
+     *     <li>'r' - pRocessing</li>
+     *   </ul>
+     *  @type array
+     *  @default []
+     */
+    "aanFeatures": [],
+
+    /**
+     * Store data information - see {@link DataTable.models.oRow} for detailed
+     * information.
+     *  @type array
+     *  @default []
+     */
+    "aoData": [],
+
+    /**
+     * Array of indexes which are in the current display (after filtering etc)
+     *  @type array
+     *  @default []
+     */
+    "aiDisplay": [],
+
+    /**
+     * Array of indexes for display - no filtering
+     *  @type array
+     *  @default []
+     */
+    "aiDisplayMaster": [],
+
+    /**
+     * Map of row ids to data indexes
+     *  @type object
+     *  @default {}
+     */
+    "aIds": {},
+
+    /**
+     * Store information about each column that is in use
+     *  @type array
+     *  @default []
+     */
+    "aoColumns": [],
+
+    /**
+     * Store information about the table's header
+     *  @type array
+     *  @default []
+     */
+    "aoHeader": [],
+
+    /**
+     * Store information about the table's footer
+     *  @type array
+     *  @default []
+     */
+    "aoFooter": [],
+
+    /**
+     * Store the applied global search information in case we want to force a
+     * research or compare the old search to a new one.
+     * Note that this parameter will be set by the initialisation routine. To
+     * set a default use {@link DataTable.defaults}.
+     *  @namespace
+     *  @extends DataTable.models.oSearch
+     */
+    "oPreviousSearch": {},
+
+    /**
+     * Store the applied global exclude information in case we want to force a
+     * research or compare the old search to a new one.
+     * Note that this parameter will be set by the initialisation routine. To
+     * set a default use {@link DataTable.defaults}.
+     *  @namespace
+     *  @extends DataTable.models.oExclude
+     */
+    "oPreviousExclude": {},
+
+    /**
+     * Store the applied search for each column - see
+     * {@link DataTable.models.oSearch} for the format that is used for the
+     * filtering information for each column.
+     *  @type array
+     *  @default []
+     */
+    "aoPreSearchCols": [],
+
+    /**
+     * Sorting that is applied to the table. Note that the inner arrays are
+     * used in the following manner:
+     * <ul>
+     *   <li>Index 0 - column number</li>
+     *   <li>Index 1 - current sorting direction</li>
+     * </ul>
+     * Note that this parameter will be set by the initialisation routine. To
+     * set a default use {@link DataTable.defaults}.
+     *  @type array
+     *  @todo These inner arrays should really be objects
+     */
+    "aaSorting": null,
+
+    /**
+     * Sorting that is always applied to the table (i.e. prefixed in front of
+     * aaSorting).
+     * Note that this parameter will be set by the initialisation routine. To
+     * set a default use {@link DataTable.defaults}.
+     *  @type array
+     *  @default []
+     */
+    "aaSortingFixed": [],
+
+    /**
+     * Classes to use for the striping of a table.
+     * Note that this parameter will be set by the initialisation routine. To
+     * set a default use {@link DataTable.defaults}.
+     *  @type array
+     *  @default []
+     */
+    "asStripeClasses": null,
+
+    /**
+     * If restoring a table - we should restore its striping classes as well
+     *  @type array
+     *  @default []
+     */
+    "asDestroyStripes": [],
+
+    /**
+     * If restoring a table - we should restore its width
+     *  @type int
+     *  @default 0
+     */
+    "sDestroyWidth": 0,
+
+    /**
+     * Callback functions array for every time a row is inserted (i.e. on a draw).
+     *  @type array
+     *  @default []
+     */
+    "aoRowCallback": [],
+
+    /**
+     * Callback functions for the header on each draw.
+     *  @type array
+     *  @default []
+     */
+    "aoHeaderCallback": [],
+
+    /**
+     * Callback function for the footer on each draw.
+     *  @type array
+     *  @default []
+     */
+    "aoFooterCallback": [],
+
+    /**
+     * Array of callback functions for draw callback functions
+     *  @type array
+     *  @default []
+     */
+    "aoDrawCallback": [],
+
+    /**
+     * Array of callback functions for row created function
+     *  @type array
+     *  @default []
+     */
+    "aoRowCreatedCallback": [],
+
+    /**
+     * Callback functions for just before the table is redrawn. A return of
+     * false will be used to cancel the draw.
+     *  @type array
+     *  @default []
+     */
+    "aoPreDrawCallback": [],
+
+    /**
+     * Callback functions for when the table has been initialised.
+     *  @type array
+     *  @default []
+     */
+    "aoInitComplete": [],
+
+
+    /**
+     * Callbacks for modifying the settings to be stored for state saving, prior to
+     * saving state.
+     *  @type array
+     *  @default []
+     */
+    "aoStateSaveParams": [],
+
+    /**
+     * Callbacks for modifying the settings that have been stored for state saving
+     * prior to using the stored values to restore the state.
+     *  @type array
+     *  @default []
+     */
+    "aoStateLoadParams": [],
+
+    /**
+     * Callbacks for operating on the settings object once the saved state has been
+     * loaded
+     *  @type array
+     *  @default []
+     */
+    "aoStateLoaded": [],
+
+    /**
+     * Cache the table ID for quick access
+     *  @type string
+     *  @default <i>Empty string</i>
+     */
+    "sTableId": "",
+
+    /**
+     * The TABLE node for the main table
+     *  @type node
+     *  @default null
+     */
+    "nTable": null,
+
+    /**
+     * Permanent ref to the thead element
+     *  @type node
+     *  @default null
+     */
+    "nTHead": null,
+
+    /**
+     * Permanent ref to the tfoot element - if it exists
+     *  @type node
+     *  @default null
+     */
+    "nTFoot": null,
+
+    /**
+     * Permanent ref to the tbody element
+     *  @type node
+     *  @default null
+     */
+    "nTBody": null,
+
+    /**
+     * Cache the wrapper node (contains all DataTables controlled elements)
+     *  @type node
+     *  @default null
+     */
+    "nTableWrapper": null,
+
+    /**
+     * Indicate if when using server-side processing the loading of data
+     * should be deferred until the second draw.
+     * Note that this parameter will be set by the initialisation routine. To
+     * set a default use {@link DataTable.defaults}.
+     *  @type boolean
+     *  @default false
+     */
+    "bDeferLoading": false,
+
+    /**
+     * Indicate if all required information has been read in
+     *  @type boolean
+     *  @default false
+     */
+    "bInitialised": false,
+
+    /**
+     * Information about open rows. Each object in the array has the parameters
+     * 'nTr' and 'nParent'
+     *  @type array
+     *  @default []
+     */
+    "aoOpenRows": [],
+
+    /**
+     * Dictate the positioning of DataTables' control elements - see
+     * {@link DataTable.model.oInit.sDom}.
+     * Note that this parameter will be set by the initialisation routine. To
+     * set a default use {@link DataTable.defaults}.
+     *  @type string
+     *  @default null
+     */
+    "sDom": null,
+
+    /**
+     * Search delay (in mS)
+     *  @type integer
+     *  @default null
+     */
+    "searchDelay": null,
+
+    /**
+     * Which type of pagination should be used.
+     * Note that this parameter will be set by the initialisation routine. To
+     * set a default use {@link DataTable.defaults}.
+     *  @type string
+     *  @default two_button
+     */
+    "sPaginationType": "two_button",
+
+    /**
+     * The state duration (for `stateSave`) in seconds.
+     * Note that this parameter will be set by the initialisation routine. To
+     * set a default use {@link DataTable.defaults}.
+     *  @type int
+     *  @default 0
+     */
+    "iStateDuration": 0,
+
+    /**
+     * Array of callback functions for state saving. Each array element is an
+     * object with the following parameters:
+     *   <ul>
+     *     <li>function:fn - function to call. Takes two parameters, oSettings
+     *       and the JSON string to save that has been thus far created. Returns
+     *       a JSON string to be inserted into a json object
+     *       (i.e. '"param": [ 0, 1, 2]')</li>
+     *     <li>string:sName - name of callback</li>
+     *   </ul>
+     *  @type array
+     *  @default []
+     */
+    "aoStateSave": [],
+
+    /**
+     * Array of callback functions for state loading. Each array element is an
+     * object with the following parameters:
+     *   <ul>
+     *     <li>function:fn - function to call. Takes two parameters, oSettings
+     *       and the object stored. May return false to cancel state loading</li>
+     *     <li>string:sName - name of callback</li>
+     *   </ul>
+     *  @type array
+     *  @default []
+     */
+    "aoStateLoad": [],
+
+    /**
+     * State that was saved. Useful for back reference
+     *  @type object
+     *  @default null
+     */
+    "oSavedState": null,
+
+    /**
+     * State that was loaded. Useful for back reference
+     *  @type object
+     *  @default null
+     */
+    "oLoadedState": null,
+
+    /**
+     * Source url for AJAX data for the table.
+     * Note that this parameter will be set by the initialisation routine. To
+     * set a default use {@link DataTable.defaults}.
+     *  @type string
+     *  @default null
+     */
+    "sAjaxSource": null,
+
+    /**
+     * Property from a given object from which to read the table data from. This
+     * can be an empty string (when not server-side processing), in which case
+     * it is  assumed an an array is given directly.
+     * Note that this parameter will be set by the initialisation routine. To
+     * set a default use {@link DataTable.defaults}.
+     *  @type string
+     */
+    "sAjaxDataProp": null,
+
+    /**
+     * Note if draw should be blocked while getting data
+     *  @type boolean
+     *  @default true
+     */
+    "bAjaxDataGet": true,
+
+    /**
+     * The last jQuery XHR object that was used for server-side data gathering.
+     * This can be used for working with the XHR information in one of the
+     * callbacks
+     *  @type object
+     *  @default null
+     */
+    "jqXHR": null,
+
+    /**
+     * JSON returned from the server in the last Ajax request
+     *  @type object
+     *  @default undefined
+     */
+    "json": undefined,
+
+    /**
+     * Data submitted as part of the last Ajax request
+     *  @type object
+     *  @default undefined
+     */
+    "oAjaxData": undefined,
+
+    /**
+     * Function to get the server-side data.
+     * Note that this parameter will be set by the initialisation routine. To
+     * set a default use {@link DataTable.defaults}.
+     *  @type function
+     */
+    "fnServerData": null,
+
+    /**
+     * Functions which are called prior to sending an Ajax request so extra
+     * parameters can easily be sent to the server
+     *  @type array
+     *  @default []
+     */
+    "aoServerParams": [],
+
+    /**
+     * Send the XHR HTTP method - GET or POST (could be PUT or DELETE if
+     * required).
+     * Note that this parameter will be set by the initialisation routine. To
+     * set a default use {@link DataTable.defaults}.
+     *  @type string
+     */
+    "sServerMethod": null,
+
+    /**
+     * Format numbers for display.
+     * Note that this parameter will be set by the initialisation routine. To
+     * set a default use {@link DataTable.defaults}.
+     *  @type function
+     */
+    "fnFormatNumber": null,
+
+    /**
+     * List of options that can be used for the user selectable length menu.
+     * Note that this parameter will be set by the initialisation routine. To
+     * set a default use {@link DataTable.defaults}.
+     *  @type array
+     *  @default []
+     */
+    "aLengthMenu": null,
+
+    /**
+     * Counter for the draws that the table does. Also used as a tracker for
+     * server-side processing
+     *  @type int
+     *  @default 0
+     */
+    "iDraw": 0,
+
+    /**
+     * Indicate if a redraw is being done - useful for Ajax
+     *  @type boolean
+     *  @default false
+     */
+    "bDrawing": false,
+
+    /**
+     * Draw index (iDraw) of the last error when parsing the returned data
+     *  @type int
+     *  @default -1
+     */
+    "iDrawError": -1,
+
+    /**
+     * Paging display length
+     *  @type int
+     *  @default 10
+     */
+    "_iDisplayLength": 10,
+
+    /**
+     * Paging start point - aiDisplay index
+     *  @type int
+     *  @default 0
+     */
+    "_iDisplayStart": 0,
+
+    /**
+     * Server-side processing - number of records in the result set
+     * (i.e. before filtering), Use fnRecordsTotal rather than
+     * this property to get the value of the number of records, regardless of
+     * the server-side processing setting.
+     *  @type int
+     *  @default 0
+     *  @private
+     */
+    "_iRecordsTotal": 0,
+
+    /**
+     * Server-side processing - number of records in the current display set
+     * (i.e. after filtering). Use fnRecordsDisplay rather than
+     * this property to get the value of the number of records, regardless of
+     * the server-side processing setting.
+     *  @type boolean
+     *  @default 0
+     *  @private
+     */
+    "_iRecordsDisplay": 0,
+
+    /**
+     * Flag to indicate if jQuery UI marking and classes should be used.
+     * Note that this parameter will be set by the initialisation routine. To
+     * set a default use {@link DataTable.defaults}.
+     *  @type boolean
+     */
+    "bJUI": null,
+
+    /**
+     * The classes to use for the table
+     *  @type object
+     *  @default {}
+     */
+    "oClasses": {},
+
+    /**
+     * Flag attached to the settings object so you can check in the draw
+     * callback if filtering has been done in the draw. Deprecated in favour of
+     * events.
+     *  @type boolean
+     *  @default false
+     *  @deprecated
+     */
+    "bFiltered": false,
+
+    /**
+     * Flag attached to the settings object so you can check in the draw
+     * callback if exclude filtering has been done in the draw. Deprecated in favour of
+     * events.
+     *  @type boolean
+     *  @default false
+     *  @deprecated
+     */
+    "bExcludeFiltered": false,
+
+    /**
+     * Flag attached to the settings object so you can check in the draw
+     * callback if sorting has been done in the draw. Deprecated in favour of
+     * events.
+     *  @type boolean
+     *  @default false
+     *  @deprecated
+     */
+    "bSorted": false,
+
+    /**
+     * Indicate that if multiple rows are in the header and there is more than
+     * one unique cell per column, if the top one (true) or bottom one (false)
+     * should be used for sorting / title by DataTables.
+     * Note that this parameter will be set by the initialisation routine. To
+     * set a default use {@link DataTable.defaults}.
+     *  @type boolean
+     */
+    "bSortCellsTop": null,
+
+    /**
+     * Initialisation object that is used for the table
+     *  @type object
+     *  @default null
+     */
+    "oInit": null,
+
+    /**
+     * Destroy callback functions - for plug-ins to attach themselves to the
+     * destroy so they can clean up markup and events.
+     *  @type array
+     *  @default []
+     */
+    "aoDestroyCallback": [],
+
+
+    /**
+     * Get the number of records in the current record set, before filtering
+     *  @type function
+     */
+    "fnRecordsTotal": function ()
+    {
+        return _fnDataSource( this ) == 'ssp' ?
+            this._iRecordsTotal * 1 :
+            this.aiDisplayMaster.length;
+    },
+
+    /**
+     * Get the number of records in the current record set, after filtering
+     *  @type function
+     */
+    "fnRecordsDisplay": function ()
+    {
+        return _fnDataSource( this ) == 'ssp' ?
+            this._iRecordsDisplay * 1 :
+            this.aiDisplay.length;
+    },
+
+    /**
+     * Get the display end point - aiDisplay index
+     *  @type function
+     */
+    "fnDisplayEnd": function ()
+    {
+        var
+            len      = this._iDisplayLength,
+            start    = this._iDisplayStart,
+            calc     = start + len,
+            records  = this.aiDisplay.length,
+            features = this.oFeatures,
+            paginate = features.bPaginate;
+
+        if ( features.bServerSide ) {
+            return paginate === false || len === -1 ?
+                start + records :
+                Math.min( start+len, this._iRecordsDisplay );
+        }
+        else {
+            return ! paginate || calc>records || len===-1 ?
+                records :
+                calc;
+        }
+    },
+
+    /**
+     * The DataTables object for this table
+     *  @type object
+     *  @default null
+     */
+    "oInstance": null,
+
+    /**
+     * Unique identifier for each instance of the DataTables object. If there
+     * is an ID on the table node, then it takes that value, otherwise an
+     * incrementing internal counter is used.
+     *  @type string
+     *  @default null
+     */
+    "sInstance": null,
+
+    /**
+     * tabindex attribute value that is added to DataTables control elements, allowing
+     * keyboard navigation of the table and its controls.
+     */
+    "iTabIndex": 0,
+
+    /**
+     * DIV container for the footer scrolling table if scrolling
+     */
+    "nScrollHead": null,
+
+    /**
+     * DIV container for the footer scrolling table if scrolling
+     */
+    "nScrollFoot": null,
+
+    /**
+     * Last applied sort
+     *  @type array
+     *  @default []
+     */
+    "aLastSort": [],
+
+    /**
+     * Stored plug-in instances
+     *  @type object
+     *  @default {}
+     */
+    "oPlugins": {},
+
+    /**
+     * Function used to get a row's id from the row's data
+     *  @type function
+     *  @default null
+     */
+    "rowIdFn": null,
+
+    /**
+     * Data location where to store a row's id
+     *  @type string
+     *  @default null
+     */
+    "rowId": null
 };


### PR DESCRIPTION
We search data from network devices and the data from these devices is stored in elasticsearch. A search (filter) query can be sent to find information (terms/keywords), but elasticsearcg also has the ability to say “not these terms” in a query as well. As such, our UI would be be designed with a query filter input and a "NOT these terms" filter input. So if you will, two global filter inputs. One input for “find this stuff” and the other input for “but not this stuff” or exclude this stuff in the results.

I have made changes to the code so that this information comes through to the server data function like so…

DEVICEREPORTS.setElasticFnServerData = function (type, indice_pattern, deviceCustomString2) {

    var recordType = type,
        service = deviceCustomString2;

    this.setFnServerData(function (sSource, aoData, fnCallback, oSettings) {
        var body,
            builder,
            draw = oSettings.iDraw,
            length = oSettings._iDisplayLength,
            start = oSettings._iDisplayStart,
            globalSearch = oSettings.oAjaxData.search.value,
            globalExclude = oSettings.oAjaxData.exclude.value,
            columnSearches = aoData[1].value,

These changes add the functionality needed for a server data function to work.
I need to learn more about the code base to make this feature work client side too.