### PR TITLE
Footer scroll fix when using the bootstrap theme

### DIFF
--- a/css/dataTables.bootstrap.scss
+++ b/css/dataTables.bootstrap.scss
@@ -166,9 +166,15 @@ div.dataTables_scrollBody {
 	}
 }
 
-div.dataTables_scrollFoot > table {
-	margin-top: 0 !important;
-	border-top: none;
+div.dataTables_scrollFoot {
+	> table {
+		margin-top: 0 !important;
+		border-top: none;
+	}
+
+	> .dataTables_scrollFootInner {
+		box-sizing: content-box;
+	}
 }
 
 


### PR DESCRIPTION
When using the bootstrap 3 theme and the option `scrollY: true`, the footer stops scrolling before the table does, causes the columns to be out of line with the footer.

**Example:**
https://jsfiddle.net/hctp0bg2/

**Fix:**
```
div.dataTables_scrollFoot  > .dataTables_scrollFootInner {
    box-sizing: content-box;
}
```

**On a side note:**
Whilst implementing this pull request it seems that the current selector `div.dataTables_scrollFoot > table { }` is never met. When `dataTables_scrollFoot` is present then the child `table` is always inside `dataTables_scrollFootInner` (not a direct child), the element with `border-top` are the `th` elements inside the `table ` and **not** the `table` itself. Hope this helps :+1: 