### PR TITLE
Bug fix for table.columns(x).visible(false)

### DIFF
--- a/js/core/core.scrolling.js
+++ b/js/core/core.scrolling.js
@@ -255,7 +255,7 @@ function _fnScrollDraw ( settings )
 
 	$.each( _fnGetUniqueThs( settings, headerCopy ), function ( i, el ) {
 		idx = _fnVisibleToColumnIndex( settings, i );
-		el.style.width = settings.aoColumns[idx].sWidth;
+		if (idx !== null) { el.style.width = settings.aoColumns[idx].sWidth; }
 	} );
 
 	if ( footer ) {


### PR DESCRIPTION
When calling `table.columns(x).visible(false)` the following error is thrown:

> TypeError: Cannot read property 'sWidth' of undefined

Apparently invisible columns are not taken into account when calculating the width of a column.

I have fixed the issue by adding a null check. The error no longer shows up in the JS console and the feature (hiding columns) works as expected.