### PR TITLE
rows([ids], {search: 'removed'}) optimization

### DIFF
--- a/js/api/api.selectors.js
+++ b/js/api/api.selectors.js
@@ -113,13 +113,22 @@ var _selector_row_indexes = function ( settings, opts )
 		}
 	}
 	else if ( order == 'current' || order == 'applied' ) {
-		a = search == 'none' ?
-			displayMaster.slice() :                      // no search
-			search == 'applied' ?
-				displayFiltered.slice() :                // applied search
-				$.map( displayMaster, function (el, i) { // removed search
-					return $.inArray( el, displayFiltered ) === -1 ? el : null;
-				} );
+		if ( search == 'none') {
+			a = displayMaster.slice();
+		} else if ( search == 'applied' ) {
+			a = displayFiltered.slice();
+		} else if ( search == 'removed' ) {
+			// Instead of looping through displayFiltered array inside the displayMaster array
+			// we create a map to avoid inner loops which will significantly increase performance 
+			// for bigger values reducing complexity from exponential to linear
+			var displayFilteredMap = {};
+			for ( var i=0; i<displayFiltered.length; i++ ) {
+				displayFilteredMap[displayFiltered[i]] = null;
+			}
+		 	a = $.map( displayMaster, function (el) {
+				return !displayFilteredMap.hasOwnProperty(el) ? el : null;
+			} );
+		}
 	}
 	else if ( order == 'index' || order == 'original' ) {
 		for ( i=0, ien=settings.aoData.length ; i<ien ; i++ ) {

--- a/js/api/api.selectors.js
+++ b/js/api/api.selectors.js
@@ -125,7 +125,7 @@ var _selector_row_indexes = function ( settings, opts )
 			for ( var i=0; i<displayFiltered.length; i++ ) {
 				displayFilteredMap[displayFiltered[i]] = null;
 			}
-		 	a = $.map( displayMaster, function (el) {
+			a = $.map( displayMaster, function (el) {
 				return !displayFilteredMap.hasOwnProperty(el) ? el : null;
 			} );
 		}


### PR DESCRIPTION
This is an optimisation that is very noticeable when using the rows([ids], {search: 'removed'}) in particular when the data table has a LOT of rows (like 50k+).

For more about this discussion check this [issue](https://github.com/DataTables/DataTablesSrc/issues/118).
