### PR TITLE
New optional placeBefore parameter for row().child.show()

### DIFF
--- a/docs/api/row().child.show().xml
+++ b/docs/api/row().child.show().xml
@@ -5,8 +5,13 @@
 	<since>1.10</since>
 
 	<type type="function">
-		<signature>row().child.show()</signature>
+		<signature>row().child.show( [placeBefore] )</signature>
 		<description>Show the child row(s) of a parent row</description>
+		<parameter type="boolean" name="placeBefore" default="false">
+			<![CDATA[
+			This optional parameter specifies whether the child row(s) are being  placed before or after the parent row. The latter is the default.
+			]]>
+		</parameter>
 		<returns type="DataTables.Api">DataTables API instance.</returns>
 	</type>
 

--- a/docs/api/row().child.xml
+++ b/docs/api/row().child.xml
@@ -7,7 +7,7 @@
 	<type type="object" />
 
 	<description>
-		DataTables has the ability to show child rows for each row (termed a "parent row" in this documentation to distinguish from the child rows). This child rows are attached to each parent row, and can be used, for example, to provide extra information about the parent row, or an editing form. The child rows will always be placed immediately after a parent row (if the child rows are designated to be visible, using the `dt-api row().child.show()` method), regardless of ordering, search terms applied to the table etc. If a parent row is not available in the DataTables' current view, the child rows will not be visible either.
+		DataTables has the ability to show child rows for each row (termed a "parent row" in this documentation to distinguish from the child rows). This child rows are attached to each parent row, and can be used, for example, to provide extra information about the parent row, or an editing form. The child rows will be placed immediately after or immediately before a parent row (if the child rows are designated to be visible, using the `dt-api row().child.show()` method), regardless of ordering, search terms applied to the table etc. If a parent row is not available in the DataTables' current view, the child rows will not be visible either.
 
 		This property is a static object of the DataTables API which is used simply to provide a namespace to its child methods, which are used to control the child row operations in DataTables.
 

--- a/js/api/api.row.details.js
+++ b/js/api/api.row.details.js
@@ -40,7 +40,11 @@ var __details_add = function ( ctx, row, data, klass )
 
 	// If the children were already shown, that state should be retained
 	if ( row._detailsShow ) {
-		row._details.insertAfter( row.nTr );
+		if ( row._detailsShow !== 2 ) {
+			row._details.insertAfter( row.nTr );
+		} else {
+			row._details.insertBefore( row.nTr );
+		}
 	}
 };
 
@@ -72,7 +76,11 @@ var __details_display = function ( api, show ) {
 			row._detailsShow = show;
 
 			if ( show ) {
-				row._details.insertAfter( row.nTr );
+				if ( show !== 2 ) {
+					row._details.insertAfter( row.nTr );
+				} else {
+					row._details.insertBefore( row.nTr );
+				}
 			}
 			else {
 				row._details.detach();
@@ -107,7 +115,11 @@ var __details_events = function ( settings )
 				var row = data[ idx ];
 
 				if ( row._detailsShow ) {
-					row._details.insertAfter( row.nTr );
+					if ( row._detailsShow !== 2 ) {
+						row._details.insertAfter( row.nTr );
+					} else {
+						row._details.insertBefore( row.nTr );
+					}
 				}
 			} );
 		} );
@@ -183,9 +195,9 @@ _api_register( _child_mth, function ( data, klass ) {
 
 _api_register( [
 	_child_obj+'.show()',
-	_child_mth+'.show()' // only when `child()` was called with parameters (without
-], function ( show ) {   // it returns an object and this method is not executed)
-	__details_display( this, true );
+	_child_mth+'.show()'      // only when `child()` was called with parameters (without
+], function ( placeBefore ) { // it returns an object and this method is not executed)
+	__details_display( this, placeBefore === true ? 2 : 1 );
 	return this;
 } );
 
@@ -194,7 +206,7 @@ _api_register( [
 	_child_obj+'.hide()',
 	_child_mth+'.hide()' // only when `child()` was called with parameters (without
 ], function () {         // it returns an object and this method is not executed)
-	__details_display( this, false );
+	__details_display( this, 0 );
 	return this;
 } );
 
@@ -212,9 +224,8 @@ _api_register( _child_obj+'.isShown()', function () {
 	var ctx = this.context;
 
 	if ( ctx.length && this.length ) {
-		// _detailsShown as false or undefined will fall through to return false
-		return ctx[0].aoData[ this[0] ]._detailsShow || false;
+		// _detailsShown as 0 or undefined will return false, otherwise true
+		return ctx[0].aoData[this[0]]._detailsShow > 0;
 	}
 	return false;
 } );
-


### PR DESCRIPTION
Makes it possible to control the placement of the child rows, either immediately after the parent row (which is the default), or (as a new option) immediately before the parent row. This can be specified on a per-row basis.