### PR TITLE
bootstrap4: use custom select menu styling

### DIFF
--- a/js/integration/dataTables.bootstrap4.js
+++ b/js/integration/dataTables.bootstrap4.js
@@ -57,7 +57,7 @@ $.extend( true, DataTable.defaults, {
 $.extend( DataTable.ext.classes, {
 	sWrapper:      "dataTables_wrapper dt-bootstrap4",
 	sFilterInput:  "form-control form-control-sm",
-	sLengthSelect: "form-control form-control-sm",
+	sLengthSelect: "custom-select custom-select-sm form-control form-control-sm",
 	sProcessing:   "dataTables_processing card",
 	sPageButton:   "paginate_button page-item"
 } );


### PR DESCRIPTION
This change ensures uniform look for the select menu across browsers when using bootstrap 4.

Before:
![image](https://user-images.githubusercontent.com/1326273/38462565-f0ea25ec-3b06-11e8-8628-a46b789f90c4.png)

After:
![image](https://user-images.githubusercontent.com/1326273/38462581-35f0675a-3b07-11e8-8e65-2e688a658565.png)


