### PR TITLE
Display a more relevant error when no column headers are present

### DIFF
--- a/js/core/core.constructor.js
+++ b/js/core/core.constructor.js
@@ -270,6 +270,11 @@ else
 	aoColumnsInit = oInit.aoColumns;
 }
 
+if ( aoColumnsInit.length === 0 )
+{
+	throw new Error("The table must contain a <thead> element with at least one column.");
+}
+
 /* Add the columns */
 for ( i=0, iLen=aoColumnsInit.length ; i<iLen ; i++ )
 {


### PR DESCRIPTION
**Before:**
http://plnkr.co/edit/mov49plvZ1LcEXti1fsx?p=preview

Notice the fairly cryptic "Uncaught TypeError: Cannot read property..." javascript error.

**After:**
http://plnkr.co/edit/nOWFB4DjpYCdXkUdwpiF?p=preview

It was a hard decision, but I'm fine if these three lines get released under the MIT license.