### PR TITLE
add handler for Http Response code - 204 No Content

### DIFF
--- a/js/core/core.ajax.js
+++ b/js/core/core.ajax.js
@@ -65,7 +65,10 @@ function _fnBuildAjax( oSettings, data, fn )
 
 	var baseAjax = {
 		"data": data,
-		"success": function (json) {
+		"success": function (json, status, xhr) {
+			if ( xhr.status === 204 ) {
+				json = {}
+			}
 			var error = json.error || json.sError;
 			if ( error ) {
 				_fnLog( oSettings, 0, error );


### PR DESCRIPTION
Hello,
This PR is w.r.t. DataTables forum discussion on handling HTTP 204 - No Content responses. 
Full discussion is [here](https://datatables.net/forums/discussion/comment/117027/#Comment_117027). 
Issue:  With ajax sourced data, when response received is 204, then dataTables throws following error:
```jquery.dataTables.js:3888 Uncaught TypeError: Cannot read property 'error' of undefined 
at Object.success (jquery.dataTables.js:3888) 
at fire (jquery.js:3291) 
at Object.fireWith [as resolveWith] (jquery.js:3421) 
at done (jquery.js:9533) 
at XMLHttpRequest.<anonymous> (jquery.js:9785)```

Proposed solution: If response returned is a null object and http status is 204, then intercept the null object and return a blank json dict object instead. 
