### PR TITLE
Remove deprecated jQuery event shorthandlers

### DIFF
--- a/js/core/core.support.js
+++ b/js/core/core.support.js
@@ -149,7 +149,7 @@ function _fnBindAction( n, oData, fn )
 {
 	$(n)
 		.on( 'click.DT', oData, function (e) {
-				$(n).blur(); // Remove focus outline for mouse users
+				$(n).trigger('blur'); // Remove focus outline for mouse users
 				fn(e);
 			} )
 		.on( 'keypress.DT', oData, function (e){

--- a/js/ext/ext.paging.js
+++ b/js/ext/ext.paging.js
@@ -185,7 +185,7 @@ $.extend( true, DataTable.ext.renderer, {
 			attach( $(host).empty(), buttons );
 
 			if ( activeEl !== undefined ) {
-				$(host).find( '[data-dt-idx='+activeEl+']' ).focus();
+				$(host).find( '[data-dt-idx='+activeEl+']' ).trigger('focus');
 			}
 		}
 	}

--- a/js/integration/dataTables.bootstrap.js
+++ b/js/integration/dataTables.bootstrap.js
@@ -173,7 +173,7 @@ DataTable.ext.renderer.pageButton.bootstrap = function ( settings, host, idx, bu
 	);
 
 	if ( activeEl !== undefined ) {
-		$(host).find( '[data-dt-idx='+activeEl+']' ).focus();
+		$(host).find( '[data-dt-idx='+activeEl+']' ).trigger('focus');
 	}
 };
 

--- a/js/integration/dataTables.bootstrap4.js
+++ b/js/integration/dataTables.bootstrap4.js
@@ -175,7 +175,7 @@ DataTable.ext.renderer.pageButton.bootstrap = function ( settings, host, idx, bu
 	);
 
 	if ( activeEl !== undefined ) {
-		$(host).find( '[data-dt-idx='+activeEl+']' ).focus();
+		$(host).find( '[data-dt-idx='+activeEl+']' ).trigger('focus');
 	}
 };
 

--- a/js/integration/dataTables.material.js
+++ b/js/integration/dataTables.material.js
@@ -184,7 +184,7 @@ DataTable.ext.renderer.pageButton.material = function ( settings, host, idx, but
 	);
 
 	if ( activeEl !== undefined ) {
-		$(host).find( '[data-dt-idx='+activeEl+']' ).focus();
+		$(host).find( '[data-dt-idx='+activeEl+']' ).trigger('focus');
 	}
 };
 

--- a/js/integration/dataTables.semanticui.js
+++ b/js/integration/dataTables.semanticui.js
@@ -184,7 +184,7 @@ DataTable.ext.renderer.pageButton.semanticUI = function ( settings, host, idx, b
 	);
 
 	if ( activeEl !== undefined ) {
-		$(host).find( '[data-dt-idx='+activeEl+']' ).focus();
+		$(host).find( '[data-dt-idx='+activeEl+']' ).trigger('focus');
 	}
 };
 

--- a/js/integration/dataTables.uikit.js
+++ b/js/integration/dataTables.uikit.js
@@ -167,7 +167,7 @@ DataTable.ext.renderer.pageButton.uikit = function ( settings, host, idx, button
 	);
 
 	if ( activeEl ) {
-		$(host).find( '[data-dt-idx='+activeEl+']' ).focus();
+		$(host).find( '[data-dt-idx='+activeEl+']' ).trigger('focus');
 	}
 };
 


### PR DESCRIPTION
jQuery event shorthands are marked as deprecated and removed in recent jQuery versions.

> jQuery.fn.blur() event shorthand is deprecated
> jQuery.fn.focus() event shorthand is deprecated

Fixes #162 