### PR TITLE
Fixes #165 - incorrect format for table-sm classes

### DIFF
--- a/css/dataTables.bootstrap4.scss
+++ b/css/dataTables.bootstrap4.scss
@@ -208,7 +208,7 @@ div.dataTables_scrollFoot {
 
 // Condensed
 table.dataTable.table-sm {
-	> thead > tr > th :not(.sorting_disabled){
+	> thead > tr > th:not(.sorting_disabled){
 		padding-right: 20px;
 	}
 


### PR DESCRIPTION
Fixes #165

I think this rule should apply to the `<th>`, and not to its children.