### PR TITLE
num-fmt does not sort correctly with French locale.

### DIFF
--- a/js/core/core.internal.js
+++ b/js/core/core.internal.js
@@ -43,7 +43,7 @@ var _re_escape_regex = new RegExp( '(\\' + [ '/', '.', '*', '+', '?', '|', '(', 
 // - Ƀ - Bitcoin
 // - Ξ - Ethereum
 //   standards as thousands separators.
-var _re_formatted_numeric = /[',$£€¥%\u2009\u202F\u20BD\u20a9\u20BArfkɃΞ]/gi;
+var _re_formatted_numeric = /['\u0020\u00A0,$£€¥%\u2009\u202F\u20BD\u20a9\u20BArfkɃΞ]/gi;
 
 
 var _empty = function ( d ) {

--- a/js/core/core.internal.js
+++ b/js/core/core.internal.js
@@ -43,7 +43,7 @@ var _re_escape_regex = new RegExp( '(\\' + [ '/', '.', '*', '+', '?', '|', '(', 
 // - Ƀ - Bitcoin
 // - Ξ - Ethereum
 //   standards as thousands separators.
-var _re_formatted_numeric = /['\u0020\u00A0,$£€¥%\u2009\u202F\u20BD\u20a9\u20BArfkɃΞ]/gi;
+var _re_formatted_numeric = /['\u00A0,$£€¥%\u2009\u202F\u20BD\u20a9\u20BArfkɃΞ]/gi;
 
 
 var _empty = function ( d ) {


### PR DESCRIPTION
In French, thousands are separated by a space. Space is not considered as thousands separator by `num-fmt`, and as a result, sorting of numbers is incorrect.

I've added regular space, and also non-breakable space ('\u00A0') as possible thousands separators, as .net core adds a non-breakable space instead of a regular one when calling `decimal.ToString()`.

This sample code shows the problem. The "Salary" column sort is incorrect: https://jsfiddle.net/ferrarimartin/oxLzrjgn/1/.