### PR TITLE
stripHTML to remove any HTML wrappers on the data prior to cell data being set

### DIFF
--- a/js/core/core.data.js
+++ b/js/core/core.data.js
@@ -618,7 +618,11 @@ function _fnGetRowElements( settings, row, colIdx, d )
 	var cellProcess = function ( cell ) {
 		if ( colIdx === undefined || colIdx === i ) {
 			col = columns[i];
-			contents = $.trim(cell.innerHTML);
+			//if specified, read data from last child of cell
+			if(col.srcDataFromLastChild && cell.lastChild){
+				cell = cell.lastChild;
+			}
+			contents = (cell.innerHTML)? cell.innerHTML.trim(): '';
 
 			if ( col && col._bAttrSrc ) {
 				var setter = _fnSetObjectDataFn( col.mData._ );

--- a/js/core/core.data.js
+++ b/js/core/core.data.js
@@ -618,11 +618,13 @@ function _fnGetRowElements( settings, row, colIdx, d )
 	var cellProcess = function ( cell ) {
 		if ( colIdx === undefined || colIdx === i ) {
 			col = columns[i];
-			//if specified, read data from last child of cell
-			if(col.srcDataFromLastChild && cell.lastChild){
-				cell = cell.lastChild;
+			//if specified, ignore additional markup and only store innerText as data
+			if(col.stripHTML){
+				contents = (cell.innerText)? cell.innerText.trim(): '';
 			}
-			contents = (cell.innerHTML)? cell.innerHTML.trim(): '';
+			else{
+				contents = (cell.innerHTML)? cell.innerHTML.trim(): '';
+			}
 
 			if ( col && col._bAttrSrc ) {
 				var setter = _fnSetObjectDataFn( col.mData._ );

--- a/js/model/model.defaults.columns.js
+++ b/js/model/model.defaults.columns.js
@@ -703,6 +703,31 @@ DataTable.defaults.column = {
 	 */
 	"sName": "",
 
+	/**
+	 * Defines whether the data is sourced directly from the td (including any HTML Structure) 
+	 * or whether the inner HTML structure is disregarded and that data is taken from the lastChild element.
+	 * 
+	 * This is useful in environments where table data may be embedded in multiple levels of HTML after the <td> element.
+	 * @name DataTable.defaults.column.srcDataFromLastChild
+	 * @type bool
+	 * @default false
+	 * 
+	 *  @example
+	 *		// Using `columnDefs`
+	 *    $(document).ready( function() {
+	 *      $('#example').dataTable( {
+	 *        "columnDefs": [
+	 *         {
+	 *         	srcDataFromLastChild: true,
+	 *         	targets : '_all'
+	 *         }
+	 *        ]
+	 *      } );
+	 *    } );
+	 *
+	 */
+	"srcDataFromLastChild": false  
+
 
 	/**
 	 * Defines a data source type for the ordering which can be used to read

--- a/js/model/model.defaults.columns.js
+++ b/js/model/model.defaults.columns.js
@@ -703,12 +703,16 @@ DataTable.defaults.column = {
 	 */
 	"sName": "",
 
+	
 	/**
-	 * Defines whether the data is sourced directly from the td (including any HTML Structure) 
-	 * or whether the inner HTML structure is disregarded and that data is taken from the lastChild element.
+	 * Defines whether the cell data includes the HTML content or not.  
+	 * This means that when the data contents of the cell are set, the innerText property is used rather than innerHTML.
 	 * 
-	 * This is useful in environments where table data may be embedded in multiple levels of HTML after the <td> element.
-	 * @name DataTable.defaults.column.srcDataFromLastChild
+	 * This is useful in environments where table data may be embedded in multiple levels of HTML after the <td> element for two reasons:-
+	 * 	-DataTables extensions such as searchPanes can compare cell data without comparing HTML data.
+	 * 	-Performance increase for processing tables which have a large amount of additional markup as less data is saved to memory.		 * 
+	 * 
+	 * @name DataTable.defaults.column.stripHTML
 	 * @type bool
 	 * @default false
 	 * 
@@ -718,7 +722,7 @@ DataTable.defaults.column = {
 	 *      $('#example').dataTable( {
 	 *        "columnDefs": [
 	 *         {
-	 *         	srcDataFromLastChild: true,
+	 *         	stripHTML: true,
 	 *         	targets : '_all'
 	 *         }
 	 *        ]
@@ -726,7 +730,7 @@ DataTable.defaults.column = {
 	 *    } );
 	 *
 	 */
-	"srcDataFromLastChild": false,
+	"stripHTML": false  
 
 
 	/**

--- a/js/model/model.defaults.columns.js
+++ b/js/model/model.defaults.columns.js
@@ -726,7 +726,7 @@ DataTable.defaults.column = {
 	 *    } );
 	 *
 	 */
-	"srcDataFromLastChild": false  
+	"srcDataFromLastChild": false,
 
 
 	/**


### PR DESCRIPTION
I am using a platform called Verj.io to create my web application. Verj.io creates tables with excess HTML within the <td> for each cell in the table. This is part of the way that Verj.io builds controls.

I found that when using datatables, some functionality (such as SearchPanes) would not work correctly because the HTML within the <td> caused each entry to be unique so every entry had a frequency of 1. Also, the searchPane ended up misforming its own rows as the HTML would be escaped incorrectly.

I have added an option to allow people using a platform like Verj.io to treat the tables as if the data were directly in the <td> element. I have allowed for this by using a stripHTML flag that can be defined in the ColumnDefs. This means that the HTML generated by Verj.io is not included in the cell data.