### PR TITLE
Correct tiny typo in model.defaults.js

### DIFF
--- a/js/model/model.defaults.js
+++ b/js/model/model.defaults.js
@@ -7,8 +7,8 @@
  * version is still, internally the primary interface, but is is not documented
  * - hence the @name tags in each doc comment. This allows a Javascript function
  * to create a map from Hungarian notation to camel case (going the other direction
- * would require each property to be listed, which would at around 3K to the size
- * of DataTables, while this method is about a 0.5K hit.
+ * would require each property to be listed, which would add around 3K to the size
+ * of DataTables, while this method is about a 0.5K hit).
  *
  * Ultimately this does pave the way for Hungarian notation to be dropped
  * completely, but that is a massive amount of work and will break current


### PR DESCRIPTION
Correct tiny typo in comment within model.defaults.js
Closes issue 169 (https://github.com/DataTables/DataTablesSrc/issues/169)

This contribution is offered under and will be made available under the project's existing license (MIT).