### PR TITLE
Closes #171

### DIFF
--- a/js/api/api.base.js
+++ b/js/api/api.base.js
@@ -177,7 +177,7 @@ _Api = function ( context, data )
 		}
 	};
 
-	if ( $.isArray( context ) ) {
+	if ( Array.isArray( context ) ) {
 		for ( var i=0, ien=context.length ; i<ien ; i++ ) {
 			ctxSettings( context[i] );
 		}
@@ -535,7 +535,7 @@ _Api.extend = function ( scope, obj, ext )
 
 _Api.register = _api_register = function ( name, val )
 {
-	if ( $.isArray( name ) ) {
+	if ( Array.isArray( name ) ) {
 		for ( var j=0, jen=name.length ; j<jen ; j++ ) {
 			_Api.register( name[j], val );
 		}
@@ -605,7 +605,7 @@ _Api.registerPlural = _api_registerPlural = function ( pluralName, singularName,
 			// New API instance returned, want the value from the first item
 			// in the returned array for the singular result.
 			return ret.length ?
-				$.isArray( ret[0] ) ?
+				Array.isArray( ret[0] ) ?
 					new _Api( ret.context, ret[0] ) : // Array results are 'enhanced'
 					ret[0] :
 				undefined;

--- a/js/api/api.legacy.js
+++ b/js/api/api.legacy.js
@@ -156,7 +156,7 @@ this.fnAddData = function( data, redraw )
 	var api = this.api( true );
 
 	/* Check if we want to add multiple rows or not */
-	var rows = $.isArray(data) && ( $.isArray(data[0]) || $.isPlainObject(data[0]) ) ?
+	var rows = Array.isArray(data) && ( Array.isArray(data[0]) || $.isPlainObject(data[0]) ) ?
 		api.rows.add( data ) :
 		api.row.add( data );
 

--- a/js/api/api.order.js
+++ b/js/api/api.order.js
@@ -43,7 +43,7 @@ _api_register( 'order()', function ( order, dir ) {
 		// Simple column / direction passed in
 		order = [ [ order, dir ] ];
 	}
-	else if ( order.length && ! $.isArray( order[0] ) ) {
+	else if ( order.length && ! Array.isArray( order[0] ) ) {
 		// Arguments passed in (list of 1D arrays)
 		order = Array.prototype.slice.call( arguments );
 	}
@@ -79,7 +79,7 @@ _api_register( 'order.fixed()', function ( set ) {
 			ctx[0].aaSortingFixed :
 			undefined;
 
-		return $.isArray( fixed ) ?
+		return Array.isArray( fixed ) ?
 			{ pre: fixed } :
 			fixed;
 	}

--- a/js/api/api.row.details.js
+++ b/js/api/api.row.details.js
@@ -6,7 +6,7 @@ var __details_add = function ( ctx, row, data, klass )
 	var rows = [];
 	var addRow = function ( r, k ) {
 		// Recursion to allow for arrays of jQuery objects
-		if ( $.isArray( r ) || r instanceof $ ) {
+		if ( Array.isArray( r ) || r instanceof $ ) {
 			for ( var i=0, ien=r.length ; i<ien ; i++ ) {
 				addRow( r[i], k );
 			}

--- a/js/api/api.rows.js
+++ b/js/api/api.rows.js
@@ -292,7 +292,7 @@ _api_register( 'row().data()', function ( data ) {
 	row._aData = data;
 
 	// If the DOM has an id, and the data source is an array
-	if ( $.isArray( data ) && row.nTr && row.nTr.id ) {
+	if ( Array.isArray( data ) && row.nTr && row.nTr.id ) {
 		_fnSetObjectDataFn( ctx[0].rowId )( data, row.nTr.id );
 	}
 

--- a/js/api/api.table.js
+++ b/js/api/api.table.js
@@ -10,7 +10,7 @@
  */
 var __table_selector = function ( selector, a )
 {
-	if ( $.isArray(selector) ) {
+	if ( Array.isArray(selector) ) {
 		return $.map( selector, function (item) {
 			return __table_selector(item, a);
 		} );

--- a/js/core/core.ajax.js
+++ b/js/core/core.ajax.js
@@ -14,7 +14,7 @@ function _fnBuildAjax( oSettings, data, fn )
 
 	// Convert to object based for 1.10+ if using the old array scheme which can
 	// come from server-side processing or serverParams
-	if ( data && $.isArray(data) ) {
+	if ( data && Array.isArray(data) ) {
 		var tmp = {};
 		var rbracket = /(.*?)\[\]$/;
 

--- a/js/core/core.columns.js
+++ b/js/core/core.columns.js
@@ -363,7 +363,7 @@ function _fnApplyColumnDefs( oSettings, aoColDefs, aoCols, fn )
 				def.targets :
 				def.aTargets;
 
-			if ( ! $.isArray( aTargets ) )
+			if ( ! Array.isArray( aTargets ) )
 			{
 				aTargets = [ aTargets ];
 			}

--- a/js/core/core.compat.js
+++ b/js/core/core.compat.js
@@ -196,7 +196,7 @@ function _fnCompatCols ( init )
 
 	// orderData can be given as an integer
 	var dataSort = init.aDataSort;
-	if ( typeof dataSort === 'number' && ! $.isArray( dataSort ) ) {
+	if ( typeof dataSort === 'number' && ! Array.isArray( dataSort ) ) {
 		init.aDataSort = [ dataSort ];
 	}
 }

--- a/js/core/core.constructor.js
+++ b/js/core/core.constructor.js
@@ -99,7 +99,7 @@ _fnLanguageCompat( oInit.oLanguage );
 // If the length menu is given, but the init display length is not, use the length menu
 if ( oInit.aLengthMenu && ! oInit.iDisplayLength )
 {
-	oInit.iDisplayLength = $.isArray( oInit.aLengthMenu[0] ) ?
+	oInit.iDisplayLength = Array.isArray( oInit.aLengthMenu[0] ) ?
 		oInit.aLengthMenu[0][0] : oInit.aLengthMenu[0];
 }
 
@@ -190,7 +190,7 @@ if ( oSettings.iInitDisplayStart === undefined )
 if ( oInit.iDeferLoading !== null )
 {
 	oSettings.bDeferLoading = true;
-	var tmp = $.isArray( oInit.iDeferLoading );
+	var tmp = Array.isArray( oInit.iDeferLoading );
 	oSettings._iRecordsDisplay = tmp ? oInit.iDeferLoading[0] : oInit.iDeferLoading;
 	oSettings._iRecordsTotal = tmp ? oInit.iDeferLoading[1] : oInit.iDeferLoading;
 }

--- a/js/core/core.data.js
+++ b/js/core/core.data.js
@@ -268,7 +268,7 @@ function _fnGetObjectDataFn( mSource )
 						innerSrc = a.join('.');
 
 						// Traverse each entry in the array getting the properties requested
-						if ( $.isArray( data ) ) {
+						if ( Array.isArray( data ) ) {
 							for ( var j=0, jLen=data.length ; j<jLen ; j++ ) {
 								out.push( fetchData( data[j], type, innerSrc ) );
 							}
@@ -371,7 +371,7 @@ function _fnSetObjectDataFn( mSource )
 					innerSrc = b.join('.');
 
 					// Traverse each entry in the array setting the properties requested
-					if ( $.isArray( val ) )
+					if ( Array.isArray( val ) )
 					{
 						for ( var j=0, jLen=val.length ; j<jLen ; j++ )
 						{

--- a/js/core/core.internal.js
+++ b/js/core/core.internal.js
@@ -271,3 +271,10 @@ var _unique = function ( src )
 	return out;
 };
 
+// Array.isArray polyfill.
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/isArray
+if (! Array.isArray) {
+    Array.isArray = function(arg) {
+        return Object.prototype.toString.call(arg) === '[object Array]';
+    };
+}

--- a/js/core/core.length.js
+++ b/js/core/core.length.js
@@ -23,7 +23,7 @@ function _fnFeatureHtmlLength ( settings )
 		classes  = settings.oClasses,
 		tableId  = settings.sTableId,
 		menu     = settings.aLengthMenu,
-		d2       = $.isArray( menu[0] ),
+		d2       = Array.isArray( menu[0] ),
 		lengths  = d2 ? menu[0] : menu,
 		language = d2 ? menu[1] : menu;
 

--- a/js/core/core.sort.js
+++ b/js/core/core.sort.js
@@ -12,7 +12,7 @@ function _fnSortFlatten ( settings )
 		fixedObj = $.isPlainObject( fixed ),
 		nestedSort = [],
 		add = function ( a ) {
-			if ( a.length && ! $.isArray( a[0] ) ) {
+			if ( a.length && ! Array.isArray( a[0] ) ) {
 				// 1D array
 				nestedSort.push( a );
 			}
@@ -24,7 +24,7 @@ function _fnSortFlatten ( settings )
 
 	// Build the sort array, with pre-fix and post-fix options if they have been
 	// specified
-	if ( $.isArray( fixed ) ) {
+	if ( Array.isArray( fixed ) ) {
 		add( fixed );
 	}
 

--- a/js/core/core.support.js
+++ b/js/core/core.support.js
@@ -69,9 +69,9 @@ function _fnLog( settings, level, msg, tn )
  */
 function _fnMap( ret, src, name, mappedName )
 {
-	if ( $.isArray( name ) ) {
+	if ( Array.isArray( name ) ) {
 		$.each( name, function (i, val) {
-			if ( $.isArray( val ) ) {
+			if ( Array.isArray( val ) ) {
 				_fnMap( ret, src, val[0], val[1] );
 			}
 			else {
@@ -123,7 +123,7 @@ function _fnExtend( out, extender, breakRefs )
 				}
 				$.extend( true, out[prop], val );
 			}
-			else if ( breakRefs && prop !== 'data' && prop !== 'aaData' && $.isArray(val) ) {
+			else if ( breakRefs && prop !== 'data' && prop !== 'aaData' && Array.isArray(val) ) {
 				out[prop] = val.slice();
 			}
 			else {

--- a/js/ext/ext.paging.js
+++ b/js/ext/ext.paging.js
@@ -86,7 +86,7 @@ $.extend( true, DataTable.ext.renderer, {
 				for ( i=0, ien=buttons.length ; i<ien ; i++ ) {
 					button = buttons[i];
 
-					if ( $.isArray( button ) ) {
+					if ( Array.isArray( button ) ) {
 						var inner = $( '<'+(button.DT_el || 'div')+'/>' )
 							.appendTo( container );
 						attach( inner, button );

--- a/js/integration/dataTables.bootstrap.js
+++ b/js/integration/dataTables.bootstrap.js
@@ -82,7 +82,7 @@ DataTable.ext.renderer.pageButton.bootstrap = function ( settings, host, idx, bu
 		for ( i=0, ien=buttons.length ; i<ien ; i++ ) {
 			button = buttons[i];
 
-			if ( $.isArray( button ) ) {
+			if ( Array.isArray( button ) ) {
 				attach( container, button );
 			}
 			else {

--- a/js/integration/dataTables.bootstrap4.js
+++ b/js/integration/dataTables.bootstrap4.js
@@ -83,7 +83,7 @@ DataTable.ext.renderer.pageButton.bootstrap = function ( settings, host, idx, bu
 		for ( i=0, ien=buttons.length ; i<ien ; i++ ) {
 			button = buttons[i];
 
-			if ( $.isArray( button ) ) {
+			if ( Array.isArray( button ) ) {
 				attach( container, button );
 			}
 			else {

--- a/js/integration/dataTables.foundation.js
+++ b/js/integration/dataTables.foundation.js
@@ -83,7 +83,7 @@ DataTable.ext.renderer.pageButton.foundation = function ( settings, host, idx, b
 		for ( i=0, ien=buttons.length ; i<ien ; i++ ) {
 			button = buttons[i];
 
-			if ( $.isArray( button ) ) {
+			if ( Array.isArray( button ) ) {
 				attach( container, button );
 			}
 			else {

--- a/js/integration/dataTables.material.js
+++ b/js/integration/dataTables.material.js
@@ -92,7 +92,7 @@ DataTable.ext.renderer.pageButton.material = function ( settings, host, idx, but
 		for ( i=0, ien=buttons.length ; i<ien ; i++ ) {
 			button = buttons[i];
 
-			if ( $.isArray( button ) ) {
+			if ( Array.isArray( button ) ) {
 				attach( container, button );
 			}
 			else {

--- a/js/integration/dataTables.semanticui.js
+++ b/js/integration/dataTables.semanticui.js
@@ -92,7 +92,7 @@ DataTable.ext.renderer.pageButton.semanticUI = function ( settings, host, idx, b
 		for ( i=0, ien=buttons.length ; i<ien ; i++ ) {
 			button = buttons[i];
 
-			if ( $.isArray( button ) ) {
+			if ( Array.isArray( button ) ) {
 				attach( container, button );
 			}
 			else {

--- a/js/integration/dataTables.uikit.js
+++ b/js/integration/dataTables.uikit.js
@@ -76,7 +76,7 @@ DataTable.ext.renderer.pageButton.uikit = function ( settings, host, idx, button
 		for ( i=0, ien=buttons.length ; i<ien ; i++ ) {
 			button = buttons[i];
 
-			if ( $.isArray( button ) ) {
+			if ( Array.isArray( button ) ) {
 				attach( container, button );
 			}
 			else {

--- a/old-tests/tests_onhold/3_ajax/ajax.js
+++ b/old-tests/tests_onhold/3_ajax/ajax.js
@@ -539,7 +539,7 @@ $(document).ready( function () {
 			} );
 		},
 		function () {
-			return $.isArray( result[0] ) && result[0].length === 0;
+			return Array.isArray( result[0] ) && result[0].length === 0;
 		}
 	);
 

--- a/old-tests/tests_onhold/4_server-side/ajax.js
+++ b/old-tests/tests_onhold/4_server-side/ajax.js
@@ -532,7 +532,7 @@ $(document).ready( function () {
 		},
 		function () {
 			console.log( result );
-			return $.isArray( result[0] ) && result[0].length === 35;
+			return Array.isArray( result[0] ) && result[0].length === 35;
 		}
 	);
 

--- a/test/options/Options/renderer.js
+++ b/test/options/Options/renderer.js
@@ -277,7 +277,7 @@ describe('renderer option page button functions', function() {
 
 	it('Arg 3 is an array of the buttons to be shown', function() {
 		expect(pageArgs[3][0]).toBe('previous');
-		expect($.isArray(pageArgs[3][1])).toBe(true);
+		expect(Array.isArray(pageArgs[3][1])).toBe(true);
 		expect(pageArgs[3][1][0]).toBe(0);
 		expect(pageArgs[3][1][1]).toBe(1);
 		expect(pageArgs[3][1].length).toBe(6);

--- a/test/options/callbacks/rowCallback.js
+++ b/test/options/callbacks/rowCallback.js
@@ -21,7 +21,7 @@ describe('rowCallback Option', function() {
 						called = true;
 						expect(arguments.length).toBe(5);
 						expect(arguments[0] instanceof HTMLElement).toBe(true);
-						expect($.isArray(arguments[1])).toBe(true);
+						expect(Array.isArray(arguments[1])).toBe(true);
 						expect(typeof arguments[2]).toBe('number');
 						expect(typeof arguments[3]).toBe('number');
 						expect(typeof arguments[4]).toBe('number');


### PR DESCRIPTION
Replaced deprecated `$.isArray` usage with `Array.isArray` as advised @ https://api.jquery.com/jQuery.isArray/

See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/isArray for browser compatibility.