### PR TITLE
Remove deprecated jQuery.trim()

### DIFF
--- a/examples/resources/demo.js
+++ b/examples/resources/demo.js
@@ -22,14 +22,14 @@ if ( window.$ ) {
 
 		// css
 		var cssContainer = $('div.tabs div.css');
-		if ( $.trim( cssContainer.find('code').text() ) === '' ) {
+		if ( ( cssContainer.find('code').text() ).trim() === '' ) {
 			cssContainer.find('code, p:eq(0), div').css('display', 'none');
 		}
 
 		// init html
 		var table = $('<p/>').append( $('table').clone() ).html();
 		
-		var demoHtml = $.trim( $('div.demo-html').html() );
+		var demoHtml = ( $('div.demo-html').html().trim() );
 
 		if ( demoHtml ) {
 			demoHtml = demoHtml+'\n\n';

--- a/js/api/api.selectors.js
+++ b/js/api/api.selectors.js
@@ -21,7 +21,7 @@ var _selector_run = function ( type, selector, selectFn, settings, opts )
 			[ selector[i] ];
 
 		for ( j=0, jen=a.length ; j<jen ; j++ ) {
-			res = selectFn( typeof a[j] === 'string' ? $.trim(a[j]) : a[j] );
+			res = selectFn( typeof a[j] === 'string' ? (a[j]).trim() : a[j] );
 
 			if ( res && res.length ) {
 				out = out.concat( res );

--- a/js/core/core.data.js
+++ b/js/core/core.data.js
@@ -618,7 +618,7 @@ function _fnGetRowElements( settings, row, colIdx, d )
 	var cellProcess = function ( cell ) {
 		if ( colIdx === undefined || colIdx === i ) {
 			col = columns[i];
-			contents = $.trim(cell.innerHTML);
+			contents = (cell.innerHTML).trim();
 
 			if ( col && col._bAttrSrc ) {
 				var setter = _fnSetObjectDataFn( col.mData._ );

--- a/js/core/core.internal.js
+++ b/js/core/core.internal.js
@@ -278,3 +278,11 @@ if (! Array.isArray) {
         return Object.prototype.toString.call(arg) === '[object Array]';
     };
 }
+
+// .trim() polyfill
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/trim
+if (!String.prototype.trim) {
+  String.prototype.trim = function () {
+    return this.replace(/^[\s\uFEFF\xA0]+|[\s\uFEFF\xA0]+$/g, '');
+  };
+}


### PR DESCRIPTION
`jQuery.trim()` has been deprecated as of jQuery 3.5

[jQuery.trim() Doc](https://api.jquery.com/jQuery.trim/)

I've replaced the jQuery trims with `String.prototype.trim` to keep it compatible.