### PR TITLE
JSON data has to be defined to test for errors

### DIFF
--- a/js/core/core.ajax.js
+++ b/js/core/core.ajax.js
@@ -66,7 +66,7 @@ function _fnBuildAjax( oSettings, data, fn )
 	var baseAjax = {
 		"data": data,
 		"success": function (json) {
-			var error = json.error || json.sError;
+			var error = typeof json == 'undefined' || json.error || json.sError;
 			if ( error ) {
 				_fnLog( oSettings, 0, error );
 			}


### PR DESCRIPTION
Robustness: json variable might be undefined.

Firefox 68-78+ (Windows, Mac) calls the success function with no parameters when page is unloading, triggering an uncaught error.