### PR TITLE
Remove redundant check from _fnCreateTr

### DIFF
--- a/js/core/core.draw.js
+++ b/js/core/core.draw.js
@@ -47,7 +47,7 @@ function _fnCreateTr ( oSettings, iRow, nTrIn, anTds )
 			cells.push( nTd );
 
 			// Need to create the HTML if new, or if a rendering function is defined
-			if ( create || ((!nTrIn || oCol.mRender || oCol.mData !== i) &&
+			if ( create || ((oCol.mRender || oCol.mData !== i) &&
 				 (!$.isPlainObject(oCol.mData) || oCol.mData._ !== i+'.display')
 			)) {
 				nTd.innerHTML = _fnGetCellData( oSettings, iRow, i, 'display' );


### PR DESCRIPTION
In this function `create == !nTrIn`, always, so checking only one of the two is fine.