### PR TITLE
Since a9ccfb4 opacity must be set for sorting_asc / sorting_desc

### DIFF
--- a/css/dataTables.bootstrap.scss
+++ b/css/dataTables.bootstrap.scss
@@ -126,10 +126,12 @@ table.dataTable thead {
 	}
 
 	.sorting_asc:after {
+		opacity: 0.5;
 		content: "\e155"; /* sort-by-attributes */
 	}
 
 	.sorting_desc:after {
+		opacity: 0.5;
 		content: "\e156"; /* sort-by-attributes-alt */
 	}
 


### PR DESCRIPTION
See [`a9ccfb4`](https://github.com/DataTables/DataTablesSrc/commit/a9ccfb4#diff-f41e330c69acf9022b01e2124c298fe0185c0a64f4a568232e6861d868ee0a7b)

---

By not removing the `sorting` class we end up with the following HTML when clicking on a table header:

```html
<th class="sorting sorting_asc" tabindex="0" aria-controls="DataTables_Table_0" rowspan="1" colspan="1" aria-label="Date/Time: activate to sort column descending">Date/Time</th>
```

As you can see we now have `.sorting.sorting_asc` as our class rather than the previous `.sorting_asc`. This in turn causes the opacity of the arrow to be wrongly set as `0.2` (rather than the required `0.5`) because of the styling that is inherited from the `.sorting` class:

https://github.com/DataTables/DataTablesSrc/blob/b2245a55b4744be18d5eb175f27bbb195ff6a2cf/css/dataTables.bootstrap.scss#L123-L126

Perhaps to rectify this we should have:

```css
.sorting_asc:after {
    opacity: 0.5; /* NEW */
    content: "\e155"; /* sort-by-attributes */
}

.sorting_desc:after {
    opacity: 0.5; /* NEW */
    content: "\e156"; /* sort-by-attributes-alt */
}
```