### PR TITLE
Fix to not always expect return string in _fnGetCellData to insert in innerHTML; and permit to call a callback 

### DIFF
--- a/js/core/core.data.js
+++ b/js/core/core.data.js
@@ -150,7 +150,7 @@ function _fnGetCellData( settings, rowIdx, colIdx, type )
 	else if ( typeof cellData === 'function' ) {
 		// If the data source is a function, then we run it and use the return,
 		// executing in the scope of the data object (for instances)
-		return cellData.call( rowData );
+		return cellData;
 	}
 
 	if ( cellData === null && type === 'display' ) {
@@ -311,7 +311,13 @@ function _fnInvalidate( settings, rowIdx, src, colIdx )
 			cell.removeChild( cell.firstChild );
 		}
 
-		cell.innerHTML = _fnGetCellData( settings, rowIdx, col, 'display' );
+		var cellData = _fnGetCellData( settings, rowIdx, col, 'display' );
+		if (typeof cellData === 'string') {
+			cell.innerHTML = cellData;
+		} else if (typeof cellData === 'function') {
+			var targetCol = settings.aoColumns[col]
+			cellData(cell, targetCol.mData ? row._aData[targetCol.mData] : col.sDefaultContent, row._aData, rowIdx)
+		}
 	};
 
 	// Are we reading last data from DOM or the data object?

--- a/js/core/core.data.js
+++ b/js/core/core.data.js
@@ -150,7 +150,7 @@ function _fnGetCellData( settings, rowIdx, colIdx, type )
 	else if ( typeof cellData === 'function' ) {
 		// If the data source is a function, then we run it and use the return,
 		// executing in the scope of the data object (for instances)
-		return cellData.call( rowData );
+		return cellData(settings.aoData[rowIdx].anCells[colIdx], col.mData ? rowData[col.mData] : defaultContent, rowData, rowIdx);
 	}
 
 	if ( cellData === null && type === 'display' ) {

--- a/js/core/core.data.js
+++ b/js/core/core.data.js
@@ -150,7 +150,11 @@ function _fnGetCellData( settings, rowIdx, colIdx, type )
 	else if ( typeof cellData === 'function' ) {
 		// If the data source is a function, then we run it and use the return,
 		// executing in the scope of the data object (for instances)
-		return cellData;
+		if (col.renderReturnType === 'function') {
+			return cellData;
+		} else {
+			return cellData.call(rowData)
+		}
 	}
 
 	if ( cellData === null && type === 'display' ) {

--- a/js/core/core.draw.js
+++ b/js/core/core.draw.js
@@ -50,7 +50,14 @@ function _fnCreateTr ( oSettings, iRow, nTrIn, anTds )
 			if ( create || ((oCol.mRender || oCol.mData !== i) &&
 				 (!$.isPlainObject(oCol.mData) || oCol.mData._ !== i+'.display')
 			)) {
-				nTd.innerHTML = _fnGetCellData( oSettings, iRow, i, 'display' );
+				
+				var cellData = _fnGetCellData( oSettings, iRow, i, 'display' );
+					
+				if (typeof cellData === 'string') {
+					nTd.innerHTML = cellData;
+				} else if (typeof cellData === 'function') {
+					cellData(nTd, oCol.mData ? row._aData[oCol.mData] : oCol.sDefaultContent, row._aData, iRow)
+				}
 			}
 
 			/* Add user defined class */


### PR DESCRIPTION
Hi Team,

IMPORTANT

Please test and accept this PR which will faciliate the following:
```
col.renderReturnType = 'function'; // only then will these changes be activated
const createdCellCallback = (tdElm, cellData, rowData, rowIndex) => {
  // dynamically insert an angular component into tdElm with help of Renderer2; passing in needed values from rowData and cellData as @Inputs to the component
}

col.render = (data, type, row, meta) => { return createdCellCallback; }

col.createdCell = createCellCallback;
```

This will faciliate blindly performing the function within returned function of col.render at all times (especially after reorder of columns)

This is in accordance to my communication over the issue thread https://github.com/DataTables/ColReorder/issues/49

Cc: @AllanJard, @SandyDatatables @colin0117  Please look into this. I would like this feature included in matter of hours to be exact, as my app relies on this! Please HELP