### PR TITLE
Bootstrap v5.1.2 and above table-striped compatiblity

### DIFF
--- a/css/dataTables.bootstrap5.scss
+++ b/css/dataTables.bootstrap5.scss
@@ -287,11 +287,11 @@ div.table-responsive > div.dataTables_wrapper > div.row {
 // Striped tables - we can't simply use the `nth-of-type` approach that Bootstrap uses
 // as it doesn't take account of injected rows (child rows, rowgroup, etc).
 table.dataTable.table-striped {
-    > tbody > tr:nth-of-type(2n+1) {
+    > tbody > tr:nth-of-type(2n+1) > * {
         --bs-table-accent-bg: transparent;
     }
 
-    > tbody > tr.odd {
+    > tbody > tr.odd > * {
         --bs-table-accent-bg: var(--bs-table-striped-bg);
     }
 }


### PR DESCRIPTION
This is the fix for Bootstrap v5.1.2 and above. I've reported this issue at https://github.com/DataTables/DataTablesSrc/issues/200