### PR TITLE
Replaced outdated IE7 CSS hacks

### DIFF
--- a/css/dataTables.jqueryui.scss
+++ b/css/dataTables.jqueryui.scss
@@ -48,11 +48,9 @@ table.dataTable {
 			margin-left: 2px;
 			text-align: center;
 			text-decoration: none !important;
+			cursor: hand;
 			@supports (cursor: pointer) {
 				cursor: pointer;
-			}
-			@supports not (cursor: point) {
-				cursor: hand;
 			}
 
 			border: 1px solid transparent;

--- a/css/dataTables.jqueryui.scss
+++ b/css/dataTables.jqueryui.scss
@@ -48,8 +48,12 @@ table.dataTable {
 			margin-left: 2px;
 			text-align: center;
 			text-decoration: none !important;
-			cursor: pointer;
-			*cursor: hand;
+			@supports (cursor: pointer) {
+				cursor: pointer;
+			}
+			@supports not (cursor: point) {
+				cursor: hand;
+			}
 
 			border: 1px solid transparent;
 

--- a/css/jquery.dataTables.scss
+++ b/css/jquery.dataTables.scss
@@ -458,7 +458,7 @@ table.dataTable td {
 		clear: both;
 
 		div.dataTables_scrollBody {
-			@supports (margin-top: -1px) {
+			@supports not (cursor: pointer) { /* workaround to apply this to IE7 & older only */
 				margin-top: -1px;
 			}
 			-webkit-overflow-scrolling: touch;

--- a/css/jquery.dataTables.scss
+++ b/css/jquery.dataTables.scss
@@ -115,11 +115,9 @@ table.dataTable {
 			.sorting_desc,
 			.sorting_asc_disabled,
 			.sorting_desc_disabled {
+				cursor: hand;
 				@supports (cursor: pointer) {
 					cursor: pointer;
-				}
-				@supports not (cursor: point) {
-					cursor: hand;
 				}
 				background-repeat: no-repeat;
 				background-position: center right;
@@ -367,11 +365,9 @@ table.dataTable td {
 			margin-left: 2px;
 			text-align: center;
 			text-decoration: none !important;
+			cursor: hand;
 			@supports (cursor: pointer) {
 				cursor: pointer;
-			}
-			@supports not (cursor: point) {
-				cursor: hand;
 			}
 
 			color: $table-control-color !important;
@@ -458,8 +454,9 @@ table.dataTable td {
 		clear: both;
 
 		div.dataTables_scrollBody {
-			@supports not (cursor: pointer) { /* workaround to apply this to IE7 & older only */
-				margin-top: -1px;
+			margin-top: -1px;
+			@supports (cursor: pointer) { /* workaround to apply this to IE7 & older only */
+				margin-top: 0px;
 			}
 			-webkit-overflow-scrolling: touch;
 

--- a/css/jquery.dataTables.scss
+++ b/css/jquery.dataTables.scss
@@ -115,8 +115,12 @@ table.dataTable {
 			.sorting_desc,
 			.sorting_asc_disabled,
 			.sorting_desc_disabled {
-				cursor: pointer;
-				*cursor: hand;
+				@supports (cursor: pointer) {
+					cursor: pointer;
+				}
+				@supports not (cursor: point) {
+					cursor: hand;
+				}
 				background-repeat: no-repeat;
 				background-position: center right;
 			}
@@ -254,7 +258,7 @@ table.dataTable {
 			>.sorting_1 { background-color: shade($table-row-background, 2%); } // shade by fa
 			>.sorting_2 { background-color: shade($table-row-background, 1.2%); } // shade by fc
 			>.sorting_3 { background-color: shade($table-row-background, 0.4%); } // shade by fe
-			
+
 			&.selected {
 				>.sorting_1 { background-color: shade($table-row-selected, 2%); }
 				>.sorting_2 { background-color: shade($table-row-selected, 1.2%); }
@@ -363,8 +367,12 @@ table.dataTable td {
 			margin-left: 2px;
 			text-align: center;
 			text-decoration: none !important;
-			cursor: pointer;
-			*cursor: hand;
+			@supports (cursor: pointer) {
+				cursor: pointer;
+			}
+			@supports not (cursor: point) {
+				cursor: hand;
+			}
 
 			color: $table-control-color !important;
 			border: 1px solid transparent;
@@ -450,7 +458,9 @@ table.dataTable td {
 		clear: both;
 
 		div.dataTables_scrollBody {
-			*margin-top: -1px;
+			@supports (margin-top: -1px) {
+				margin-top: -1px;
+			}
 			-webkit-overflow-scrolling: touch;
 
 			> table > thead > tr, > table > tbody > tr {

--- a/examples/resources/syntax/shCore.css
+++ b/examples/resources/syntax/shCore.css
@@ -383,11 +383,9 @@
 
 .datatables_ref:hover {
 	text-decoration: underline;
+	cursor: hand;
 	@supports (cursor: pointer) {
 		cursor: pointer;
-	}
-	@supports not (cursor: point) {
-		cursor: hand;
 	}
 }
 
@@ -397,11 +395,9 @@
 
 .syntaxhighlighter .dtapi:hover {
 	text-decoration: underline;
+	cursor: hand;
 	@supports (cursor: pointer) {
 		cursor: pointer;
-	}
-	@supports not (cursor: point) {
-		cursor: hand;
 	}
 }
 

--- a/examples/resources/syntax/shCore.css
+++ b/examples/resources/syntax/shCore.css
@@ -7,7 +7,7 @@
  *
  * @version
  * 3.0.83 (July 02 2010)
- * 
+ *
  * @copyright
  * Copyright (C) 2004-2010 Alex Gorbatchev.
  *
@@ -258,7 +258,7 @@
  *
  * @version
  * 3.0.83 (July 02 2010)
- * 
+ *
  * @copyright
  * Copyright (C) 2004-2010 Alex Gorbatchev.
  *
@@ -383,8 +383,12 @@
 
 .datatables_ref:hover {
 	text-decoration: underline;
-	cursor: pointer;
-	*cursor: hand;
+	@supports (cursor: pointer) {
+		cursor: pointer;
+	}
+	@supports not (cursor: point) {
+		cursor: hand;
+	}
 }
 
 .syntaxhighlighter .dtapi {
@@ -393,8 +397,12 @@
 
 .syntaxhighlighter .dtapi:hover {
 	text-decoration: underline;
-	cursor: pointer;
-	*cursor: hand;
+	@supports (cursor: pointer) {
+		cursor: pointer;
+	}
+	@supports not (cursor: point) {
+		cursor: hand;
+	}
 }
 
 .syntaxhighlighter table {


### PR DESCRIPTION
Parcel versions 2.4.0 & 2.4.1 refuse to build if any dependency has invalid CSS.  This has created an incompatibility with various other projects including DataTables, and the Parcels maintainer has expressed a strong preference for fixing all the other projects rather than loosening the constraint: https://github.com/parcel-bundler/parcel/issues/7854

Fortunately, in this project the issue seems to be confined to a handful of CSS declarations that use the very nonstandard [*propertyname hack for IE7 and older](https://stackoverflow.com/questions/1690642/purpose-of-asterisk-before-a-css-property).  This PR simply replaces each instance of that hack with the modern, standards-compliant [`@supports` construct](https://developer.mozilla.org/en-US/docs/Web/CSS/@supports).  In each instance, the IE-specific rule is first, followed by an `@supports` block that overrides it for more modern browsers.  It's written in this slightly counterintuitive way because IE does not itself support `@supports`.

I would also be happy with dropping IE<=7 support entirely, or allowing a little degradation in those very old browsers by dropping these specific CSS rules.  But I do not feel that that's my decision to make!  So this is an attempt to maintain that support while complying with modern CSS standards.

Unfortunately I am not able to test this work in IE as I work on a Mac.

All work in this PR is offered under the MIT License.