### PR TITLE
prevent lengthMenu manipulation through the dom

### DIFF
--- a/js/core/core.length.js
+++ b/js/core/core.length.js
@@ -1,8 +1,15 @@
 
 function _fnLengthChange ( settings, val )
 {
-	var len = parseInt( val, 10 );
-	settings._iDisplayLength = len;
+	// val: is coming directily from the dom 
+	var len = parseInt(val, 10),
+	    //Add a way to prevent end user from changing the lengthMenu value in the dom
+	    menu = settings.aLengthMenu,
+	    d2 = Array.isArray(menu[0]),
+	    originalLengths = d2 ? menu[0] : menu;
+	// if the value is not in the original values when initiating the data table then choose the min value
+	// this will be of use when using ssp whith large tables where you want to make sure that there is a LIMIT restriction
+	settings._iDisplayLength = originalLengths.includes(len) ? len : Math.min(...originalLengths);
 
 	_fnLengthOverflow( settings );
 


### PR DESCRIPTION
this will add a way to prevent a server hit on large tables if the end user has changed the length value through the dom

![lengthMenu](https://user-images.githubusercontent.com/40702435/214798238-8ce8dbeb-8170-4166-b70b-0630a5a4d6c1.PNG)
