### PR TITLE
types: Fix column definitions and oSort

### DIFF
--- a/types.d.ts
+++ b/types.d.ts
@@ -521,12 +521,16 @@ export interface ConfigColumns {
     width?: string;
 }
 
-export interface ConfigColumnDefs extends ConfigColumns {
+export type ConfigColumnDefs = ConfigColumnDefsMultiple | ConfigColumnDefsSingle;
+
+export interface ConfigColumnDefsMultiple extends ConfigColumns {
     /**
      * Target column(s). Either this or `target` must be specified.
      */
-    targets?: string | number | Array<(number | string)>;
+    targets: string | number | Array<(number | string)>;
+}
 
+export interface ConfigColumnDefsSingle extends ConfigColumns {
     /**
      * Single column target. Either this or `targets` must be specified. Since: 1.12
      */

--- a/types.d.ts
+++ b/types.d.ts
@@ -2328,6 +2328,7 @@ export interface ApiStaticExt {
     legacy: object;
     oApi: object;
     order: object;
+    oSort: object;
     pager: object;
     renderer: object;
     search: any[];


### PR DESCRIPTION
Two fixes for the TypeScript definitions:

1. Require either `targets` or `target` on a column definition. The current types don't work because they require `target` to be specified, even when `targets` are given.
2. Add `oSort` on the definitions for `ext`.