### PR TITLE
Fix bug causing the table to always scroll back to the first row after an Ajax reload

### DIFF
--- a/js/core/core.ajax.js
+++ b/js/core/core.ajax.js
@@ -153,11 +153,16 @@ function _fnAjaxUpdate( settings )
 	settings.iDraw++;
 	_fnProcessingDisplay( settings, true );
 
+	// Keep track of drawHold state to handle scrolling after the Ajax call
+	var drawHold = settings._drawHold;
+
 	_fnBuildAjax(
 		settings,
 		_fnAjaxParameters( settings ),
 		function(json) {
+			settings._drawHold = drawHold;
 			_fnAjaxUpdateDraw( settings, json );
+			settings._drawHold = false;
 		}
 	);
 }


### PR DESCRIPTION
This is a fix for issue #238.

DataTables will always reset the scroll position to the top of the table on an `ajax.reload()`, even if the `resetPaging` parameter is `false` (e.g. `ajax.reload(null, false)`).

A demo illustrating the problem is available [here](https://live.datatables.net/cubucoli/1/edit). The table will reload once per second, resetting the scroll position.

A demo with the fix applied is available [here](https://live.datatables.net/fipuyiho/1/edit).