### PR TITLE
Use aria-label from table header if available

### DIFF
--- a/docs/option/columns.ariaTitle.xml
+++ b/docs/option/columns.ariaTitle.xml
@@ -10,7 +10,7 @@
 	</default>
 
 	<description>
-		This option can be used to provide a custom string for the `aria-label` attribute used for column headers to provide enhanced accessibility for screenreaders. By default DataTables will use the column title (`-init columns.title`, or read from the document), but this option provides customisation for that.
+		This option can be used to provide a custom string for the `aria-label` attribute used for column headers to provide enhanced accessibility for screenreaders. By default, DataTables will use an existing `aria-label` attribute or the column title (`-init columns.title`, or read from the document), but this option provides customisation for that.
 
 		Please note that the value given here will have `-init language.aria.sortAscending` or `-init language.aria.sortDescending` appended to it if the column can be ordered by the end user, to give an indication to screenreader users that this is the case. 
 	</description>

--- a/docs/option/columns.ariaTitle.xml
+++ b/docs/option/columns.ariaTitle.xml
@@ -10,9 +10,9 @@
 	</default>
 
 	<description>
-		This option can be used to provide a custom string for the `aria-label` attribute used for column headers to provide enhanced accessibility for screenreaders. By default DataTables will use the column title (`-init columns.title`, or read from the document), but this option provides customisation for that.
+		This option can be used to provide a custom string for the `aria-label` attribute used for column headers to provide enhanced accessibility for screenreaders. By default, DataTables will use an existing `aria-label` attribute or the column title (`-init columns.title`, or read from the document), but this option provides customisation for that.
 
-		Please note that the value given here will have `-init language.aria.sortAscending` or `-init language.aria.sortDescending` appended to it if the column can be ordered by the end user, to give an indication to screenreader users that this is the case. 
+		Please note that the value given here will have `-init language.aria.sortAscending` or `-init language.aria.sortDescending` appended to it if the column can be ordered by the end user, to give an indication to screenreader users that this is the case.
 	</description>
 
 	<example title="Set the first column's aria-label with `dt-init columnDefs`"><![CDATA[

--- a/docs/option/columns.ariaTitle.xml
+++ b/docs/option/columns.ariaTitle.xml
@@ -10,9 +10,9 @@
 	</default>
 
 	<description>
-		This option can be used to provide a custom string for the `aria-label` attribute used for column headers to provide enhanced accessibility for screenreaders. By default, DataTables will use an existing `aria-label` attribute or the column title (`-init columns.title`, or read from the document), but this option provides customisation for that.
+		This option can be used to provide a custom string for the `aria-label` attribute used for column headers to provide enhanced accessibility for screenreaders. By default DataTables will use the column title (`-init columns.title`, or read from the document), but this option provides customisation for that.
 
-		Please note that the value given here will have `-init language.aria.sortAscending` or `-init language.aria.sortDescending` appended to it if the column can be ordered by the end user, to give an indication to screenreader users that this is the case.
+		Please note that the value given here will have `-init language.aria.sortAscending` or `-init language.aria.sortDescending` appended to it if the column can be ordered by the end user, to give an indication to screenreader users that this is the case. 
 	</description>
 
 	<example title="Set the first column's aria-label with `dt-init columnDefs`"><![CDATA[

--- a/js/core/core.columns.js
+++ b/js/core/core.columns.js
@@ -104,6 +104,10 @@ function _fnColumnOptions( oSettings, iCol, oOptions )
 			oCol.aDataSort = [ oOptions.iDataSort ];
 		}
 		_fnMap( oCol, oOptions, "aDataSort" );
+
+		// Fall back to the aria-label attribute on the table header if no ariaTitle is
+		// provided.
+		oCol.ariaTitle ||= th.attr("aria-label");
 	}
 
 	/* Cache the data get and set functions for speed */

--- a/js/core/core.sort.js
+++ b/js/core/core.sort.js
@@ -212,8 +212,8 @@ function _fnSortAria ( settings )
 	{
 		var col = columns[i];
 		var asSorting = col.asSorting;
+		var sTitle = col.ariaTitle || col.sTitle.replace( /<.*?>/g, "" );
 		var th = col.nTh;
-		var sTitle = col.ariaTitle || th.getAttribute('aria-title') || col.sTitle.replace( /<.*?>/g, "" );
 
 		// IE7 is throwing an error when setting these properties with jQuery's
 		// attr() and removeAttr() methods...

--- a/js/core/core.sort.js
+++ b/js/core/core.sort.js
@@ -212,8 +212,8 @@ function _fnSortAria ( settings )
 	{
 		var col = columns[i];
 		var asSorting = col.asSorting;
-		var sTitle = col.ariaTitle || col.sTitle.replace( /<.*?>/g, "" );
 		var th = col.nTh;
+		var sTitle = col.ariaTitle || th.getAttribute('aria-title') || col.sTitle.replace( /<.*?>/g, "" );
 
 		// IE7 is throwing an error when setting these properties with jQuery's
 		// attr() and removeAttr() methods...

--- a/test/options/columns/columns_ariaTitle.js
+++ b/test/options/columns/columns_ariaTitle.js
@@ -5,30 +5,54 @@ describe('columns.ariaTitle option', function () {
 	});
 
 	describe('Check the option', function () {
-		dt.html('basic');
+		dt.html('basic_wide');
 		it('Defaults', function () {
+			$('thead th:eq(4)').attr('aria-label', 'test4');
+			$('thead th:eq(5)').attr('aria-label', 'test5a');
+			$('thead th:eq(6)').attr('aria-label', 'test6a');
+			$('thead th:eq(7)').attr('aria-label', 'test7a');
+
 			$('#example').dataTable({
 				columnDefs: [
 					{targets: 0, ariaTitle: 'test1'},
 					{targets: 1, title: 'test2'},
-					{targets: 2, ariaTitle: 'test3a', title: 'test3t'}
+					{targets: 2, ariaTitle: 'test3o', title: 'test3t'},
+					{targets: 5, ariaTitle: 'test5o'},
+					{targets: 6, title: 'test6t'},
+					{targets: 7, ariaTitle: 'test7o', title: 'test7t'}
 				]
 			});
 
-			expect($('thead th:eq(3)').attr('aria-label')).toBe('Age: activate to sort column ascending');
-			expect($('thead th:eq(3)').text()).toBe('Age');
+			expect($('thead th:eq(3)').attr('aria-label')).toBe('Office: activate to sort column ascending');
+			expect($('thead th:eq(3)').text()).toBe('Office');
 		});
 		it('Just ariaTitle', function () {
 			expect($('thead th:eq(0)').attr('aria-label')).toBe('test1: activate to sort column descending');
-			expect($('thead th:eq(0)').text()).toBe('Name');
+			expect($('thead th:eq(0)').text()).toBe('First name');
 		});
 		it('Just ariaTitle', function () {
 			expect($('thead th:eq(1)').attr('aria-label')).toBe('test2: activate to sort column ascending');
 			expect($('thead th:eq(1)').text()).toBe('test2');
 		});
 		it('Both ariaTitle and title', function () {
-			expect($('thead th:eq(2)').attr('aria-label')).toBe('test3a: activate to sort column ascending');
+			expect($('thead th:eq(2)').attr('aria-label')).toBe('test3o: activate to sort column ascending');
 			expect($('thead th:eq(2)').text()).toBe('test3t');
+		});
+		it('Just aria-label', function () {
+			expect($('thead th:eq(4)').attr('aria-label')).toBe('test4: activate to sort column ascending');
+			expect($('thead th:eq(4)').text()).toBe('Age');
+		});
+		it('Both ariaTitle and aria-label', function () {
+			expect($('thead th:eq(5)').attr('aria-label')).toBe('test5o: activate to sort column ascending');
+			expect($('thead th:eq(5)').text()).toBe('Start date');
+		});
+		it('Both aria-label and title', function () {
+			expect($('thead th:eq(6)').attr('aria-label')).toBe('test6a: activate to sort column ascending');
+			expect($('thead th:eq(6)').text()).toBe('test6t');
+		});
+		it('ariaTitle, aria-label, and title', function () {
+			expect($('thead th:eq(7)').attr('aria-label')).toBe('test7o: activate to sort column ascending');
+			expect($('thead th:eq(7)').text()).toBe('test7t');
 		});
 	});
 });


### PR DESCRIPTION
I was surprised to find that `aria-label` attributes of `th` elements were getting overwritten by DataTables even though I did not use the `columns.ariaTitle` option. The overwrite is caused within `_fnSortAria` which assigns either the value of the `columns.ariaTitle` option or the column title to `sTitle`:

```js
var sTitle = col.ariaTitle || col.sTitle.replace( /<.*?>/g, "" );
```

In my opinion, an explicitly specified `aria-label` attribute should take precedence over deducing a label from the column title via `col.sTitle.replace( /<.*?>/g, "" );` which would then result in the following priorities:

1. A `columns.ariaTitle` value provided within the script
2. An existing `aria-label` provided within the document
3. A generated label derived from the column title as a fallback

## Context

For a bit of additional context: I am templating HTML on the server. For localization purposes it would be easiest to directly write a localized `aria-label` into the generated document.  
However, because the attribute currently gets overwritten by DataTables, the label text must be stored elsewhere (e.g., a `data-*` attribute or a hidden `div`), loaded from DOM, and then assigned to `columns.ariaTitle`, which feels a bit cumbersome.

I'd be glad to have my contribution included under the MIT license.