### PR TITLE
Fix: Sorting Icon Position of Bootstrap 5 table-sm tables

### DIFF
--- a/css/dataTables.bootstrap5.scss
+++ b/css/dataTables.bootstrap5.scss
@@ -166,6 +166,10 @@ div.dataTables_scrollFoot {
 table.dataTable.table-sm {
 	> thead > tr > th:not(.sorting_disabled){
 		padding-right: 20px;
+        	&:before,
+        	&:after {
+          		right: 5px;
+        	}
 	}
 }
 


### PR DESCRIPTION
The right padding is reduced from 26px to 20px. But the position of the icons is still 10px from right. The icons have a width of 10px. So the text have no spacing to the icons:
![Screenshot 2023-09-08 100130](https://github.com/DataTables/DataTablesSrc/assets/998558/af6a117d-7828-41a0-9312-268a57b4bd36)

After my change the icons are 5px from right. So it have also 5px spacing to the text:
![Screenshot 2023-09-08 100145](https://github.com/DataTables/DataTablesSrc/assets/998558/18596635-7ebf-4d04-9ef8-101c4f0ca180)
