### PR TITLE
[BUG] fix DT overwriting children td colspan when td already has a colspan.

### DIFF
--- a/js/api/api.row.details.js
+++ b/js/api/api.row.details.js
@@ -180,7 +180,12 @@ var __details_events = function ( settings )
 				row = data[i];
 
 				if ( row._details ) {
-					row._details.children('td[colspan]').attr('colspan', visible );
+					row._details.each(function () {
+						var el = $(this);
+						if (el.children('td').length == 1) {
+							el.children('td[colspan]').attr('colspan', visible);
+						}
+					});
 				}
 			}
 		} );

--- a/js/api/api.row.details.js
+++ b/js/api/api.row.details.js
@@ -166,6 +166,25 @@ var __details_events = function ( settings )
 			} );
 		} );
 
+		// Column visibility change - update the colspan
+		api.on( colvisEvent, function ( e, ctx, idx, vis ) {
+			if ( settings !== ctx ) {
+				return;
+			}
+
+			// Update the colspan for the details rows (note, only if it already has
+			// a colspan)
+			var row, visible = _fnVisbleColumns( ctx );
+
+			for ( var i=0, ien=data.length ; i<ien ; i++ ) {
+				row = data[i];
+
+				if ( row._details ) {
+					row._details.children('td[colspan]').attr('colspan', visible );
+				}
+			}
+		} );
+
 		// Table destroyed - nuke any child rows
 		api.on( destroyEvent, function ( e, ctx ) {
 			if ( settings !== ctx ) {

--- a/js/api/api.row.details.js
+++ b/js/api/api.row.details.js
@@ -166,25 +166,6 @@ var __details_events = function ( settings )
 			} );
 		} );
 
-		// Column visibility change - update the colspan
-		api.on( colvisEvent, function ( e, ctx, idx, vis ) {
-			if ( settings !== ctx ) {
-				return;
-			}
-
-			// Update the colspan for the details rows (note, only if it already has
-			// a colspan)
-			var row, visible = _fnVisbleColumns( ctx );
-
-			for ( var i=0, ien=data.length ; i<ien ; i++ ) {
-				row = data[i];
-
-				if ( row._details ) {
-					row._details.children('td[colspan]').attr('colspan', visible );
-				}
-			}
-		} );
-
 		// Table destroyed - nuke any child rows
 		api.on( destroyEvent, function ( e, ctx ) {
 			if ( settings !== ctx ) {


### PR DESCRIPTION
Consider a table that has 7 columns, and the following child template:

```html
<template>
    <tr>
        <td>Something...</td>
        <td colspan="5">Something...</td>
        <td>Something...</td>
    </tr>
</template>
```

When DataTables render it, the colspan attribute get overwritten by the visible column count breaking the layout:

```html
<tr>
    <td>Something...</td>
    <td colspan="7">Something...</td>
    <td>Something...</td>
</tr>
```

If every `<td>` has a colspan attribute, all of them get overwritten by the column count.

```html
<tr>
    <td colspan="2">Something...</td>
    <td colspan="3">Something...</td>
    <td colspan="2">Something...</td>
</tr>
```

To:

```html
<tr>
    <td colspan="7">Something...</td>
    <td colspan="7">Something...</td>
    <td colspan="7">Something...</td>
</tr>
```
