### PR TITLE
Add dynamic defaults

### DIFF
--- a/js/core/core.constructor.js
+++ b/js/core/core.constructor.js
@@ -2,7 +2,7 @@
 var i=0, iLen, j, jLen, k, kLen;
 var sId = this.getAttribute( 'id' );
 var bInitHandedOff = false;
-var defaults = DataTable.defaults;
+var defaults = typeof DataTable.defaultsFunction === 'function' ? DataTable.defaultsFunction.call(this) : DataTable.defaults;
 var $this = $(this);
 
 


### PR DESCRIPTION
Useful for retrieving default values from Ajax or for defining certain parameters using a function) :
```js
$.fn.dataTable.defaults = function(){
    myDefault = $.extend({}, $.fn.dataTable.defaults, { "serverSide": true });
    myDefault.stateSave = getFromAjax($(this).attr("id"), "stateSave");
    return myDefault;
}
```