### PR TITLE
Add aria-label to page length select for accessibility

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -37,6 +37,11 @@ A number of programs are required out your computer to be able to build DataTabl
 * [Sass](https://sass-lang.com/install) - CSS compiler
 * [JSHint 2.1+](https://jshint.com/install/) - Linter (optional)
 
+PHP Libraries
+
+* [libcurl](https://curl.se/) (On ubuntu `sudo apt-get install php-curl`)
+* xml (On ubunutu `sudo apt-get install php-xml`)
+
 The build script assumes that a Mac or Linux environment is being used - Windows builds are not currently directly supported (although would be possible using [Cygwin](https://www.cygwin.com/)). Additionally, you may need to alter the paths for the above programs to reflect where they are installed on your own computer - this can be done in the [`build/include.sh`](build/include.sh) script.
 
 The output files are placed into `built/DataTables/` which is a temporary directory. No changes should be made in that directory as they will be **overwritten** when you next build the software.

--- a/build/lib/markdown.php
+++ b/build/lib/markdown.php
@@ -1656,9 +1656,9 @@ class Markdown_Parser {
 	# regular expression.
 	#
 		if (function_exists($this->utf8_strlen)) return;
-		$this->utf8_strlen = create_function('$text', 'return preg_match_all(
-			"/[\\\\x00-\\\\xBF]|[\\\\xC0-\\\\xFF][\\\\x80-\\\\xBF]*/", 
-			$text, $m);');
+		$this->utf8_strlen = function($text) {
+			return preg_match_all("/[\\x00-\\xBF]|[\\xC0-\\xFF][\\x80-\\xBF]*/", $text, $m);
+		};
 	}
 
 

--- a/build/make.sh
+++ b/build/make.sh
@@ -70,6 +70,8 @@ function build_js {
 		else
 			echo_error "JSHint failed"
 		fi
+	else
+		echo_msg "No JSHint installed"
 	fi
 
 	js_compress $OUT_FILE
@@ -375,8 +377,10 @@ function usage {
 #
 cd $BASE_DIR
 
+CURR_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+
 echo ""
-echo_section "DataTables build ($VERSION) - branch: $SYNC_BRANCH"
+echo_section "DataTables build ($VERSION) - branch: $CURR_BRANCH"
 echo ""
 
 

--- a/js/core/core.length.js
+++ b/js/core/core.length.js
@@ -25,11 +25,13 @@ function _fnFeatureHtmlLength ( settings )
 		menu     = settings.aLengthMenu,
 		d2       = Array.isArray( menu[0] ),
 		lengths  = d2 ? menu[0] : menu,
-		language = d2 ? menu[1] : menu;
+		language = d2 ? menu[1] : menu,
+		oAria    = settings.oLanguage.oAria;
 
 	var select = $('<select/>', {
 		'name':          tableId+'_length',
 		'aria-controls': tableId,
+		'aria-label':    oAria.sPageLength,
 		'class':         classes.sLengthSelect
 	} );
 

--- a/js/model/model.defaults.js
+++ b/js/model/model.defaults.js
@@ -1440,7 +1440,28 @@ DataTable.defaults = {
 			 *      } );
 			 *    } );
 			 */
-			"sSortDescending": ": activate to sort column descending"
+			"sSortDescending": ": activate to sort column descending",
+
+			/**
+			 * ARIA label that is added to the length select list
+			 *  @type string
+			 *  @default : Page Length
+			 *
+			 *  @dtopt Language
+			 *  @name DataTable.defaults.language.aria.sortDescending
+			 *
+			 *  @example
+			 *    $(document).ready( function() {
+			 *      $('#example').dataTable( {
+			 *        "language": {
+			 *          "aria": {
+			 *            "pageLength": " - Page Length Select Menu"
+			 *          }
+			 *        }
+			 *      } );
+			 *    } );
+			 */
+			"sPageLength": "Page Length"
 		},
 
 		/**


### PR DESCRIPTION
I have added an aria-label attribute to the length select menu. I tried to follow the pattern I had seen on the sort element aria code using oAria settings.

I ended up running the make file build scripts and during that I found that create_function was removed from the newest major version of PHP. I have switched over to an anonymous function. It didn't seem to cause any issues on my end but if you'd prefer that I remove that part from this PR I would be more than happy to do so. 

I also noticed that the build script would always print out that you were building master even if that wasn't true, so I tweaked it to show the current branch so it's not confusing. Once again, I can remove that if you prefer.

I have built and copied the output into a working site on one of my active internal projects and it worked great with no defects that I have noticed.

Please let me know if there's anything you'd like me to tweak.

This is a very minor change so I'm hoping it can go out before version 2.0 if you decide to publish another version.