### PR TITLE
Fix copy&pasted typos in documentation

### DIFF
--- a/docs/api/flatten().xml
+++ b/docs/api/flatten().xml
@@ -13,7 +13,7 @@
 	<description>
 		This method will reduce a 2D array structure to a simple 1D structure, which can be particularly useful when working with the plural methods such as `dt-api rows()` and `dt-api columns()` which can return 2D structures data (for example in the columns data, each column has its own array of information).
 
-		This method makes use of the fact that DataTables API objects are "array like", in that they inherent a lot of the abilities and methods of the Javascript `Array` type.
+		This method makes use of the fact that DataTables API objects are "array like", in that they inherit a lot of the abilities and methods of the Javascript `Array` type.
 	</description>
 
 	<example title="Get the data from two columns in a single array"><![CDATA[

--- a/docs/api/includes().xml
+++ b/docs/api/includes().xml
@@ -16,7 +16,7 @@
 	<description>
 		You may find it useful to know if an API instance's result set contains a particular value. While that can be achieved readily with `-api indexOf()`, this utility method can be a useful short-cut if you don't need to know the value's location in the result set.
 
-		This method makes use of the fact that DataTables API objects are "array like", in that they inherent a lot of the abilities and methods of the Javascript `Array` type.
+		This method makes use of the fact that DataTables API objects are "array like", in that they inherit a lot of the abilities and methods of the Javascript `Array` type.
 	</description>
 
 	<example title="Check if a value is visible on the current page"><![CDATA[

--- a/docs/api/indexOf().xml
+++ b/docs/api/indexOf().xml
@@ -16,7 +16,7 @@
 	<description>
 		It is often very useful to know if a value is in a result set, and further, what its position is in the result set if it is present. This method provides exactly that ability, searching for the value given, starting from index 0 (see `dt-api lastIndexOf()` for starting at the end of the array) and giving its position in the result set.
 
-		This method makes use of the fact that DataTables API objects are "array like", in that they inherent a lot of the abilities and methods of the Javascript `Array` type.
+		This method makes use of the fact that DataTables API objects are "array like", in that they inherit a lot of the abilities and methods of the Javascript `Array` type.
 
 		In this case, this method is a proxy for the Javascript `Array.prototype.indexOf` method and is provided as a utility method for the DataTables API. For more information about the original method, please refer to the [Mozilla MDN documentation for `indexOf`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/indexOf). In browsers which do not support `indexOf` natively, a polyfill is provided to allow this DataTables method to operate as expected.
 	</description>

--- a/docs/api/join().xml
+++ b/docs/api/join().xml
@@ -16,7 +16,7 @@
 	<description>
 		This method operates in exactly the same way as the Javascript array `join` method, combining the contents of the array (in this case the API instance) into a single string.
 
-		This method makes use of the fact that DataTables API objects are "array like", in that they inherent a lot of the abilities and methods of the Javascript `Array` type.
+		This method makes use of the fact that DataTables API objects are "array like", in that they inherit a lot of the abilities and methods of the Javascript `Array` type.
 
 		In this case, this method is a proxy for the Javascript `Array.prototype.join` method and is provided as a utility method for the DataTables API. For more information about the original method, please refer to the [Mozilla MDN documentation for concat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/join).
 	</description>

--- a/docs/api/length.xml
+++ b/docs/api/length.xml
@@ -9,7 +9,7 @@
 	<description>
 		This option defines the number of elements that are stored in an API instance's result set.
 
-		This property makes use of the fact that DataTables API objects are "array like", in that they inherent a lot of the abilities and methods of the Javascript `Array` type.
+		This property makes use of the fact that DataTables API objects are "array like", in that they inherit a lot of the abilities and methods of the Javascript `Array` type.
 
 		In this case, this property is basically the same as the `Array.length` property. For more information about the original property, please refer to the [Mozilla MDN documentation for `length`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/length).
 	</description>

--- a/docs/api/map().xml
+++ b/docs/api/map().xml
@@ -22,7 +22,7 @@
 	<description>
 		The `dt-api map()` method is useful for traversing a result set and creating a new instance, whose result set is defined by the values returned. As such any logic condition can be applied to the values of the original result set, transforming the data as required.
 
-		This method makes use of the fact that DataTables API objects are "array like", in that they inherent a lot of the abilities and methods of the Javascript `Array` type.
+		This method makes use of the fact that DataTables API objects are "array like", in that they inherit a lot of the abilities and methods of the Javascript `Array` type.
 
 		**Important compatibility note**: This method is implemented in the same way as the ECMA-262 5th edition `Array.prototype.map` method and is not identical to [jQuery's `$.map` method](https://api.jquery.com/jquery.map/). The key difference is in how the returned value is handled. The ECMAScript standard requires that the resulting array (DataTables API instance in this case) is of identical length as the input array, while that is not true in `$.map`. When using jQuery's `$.map` method `null` or `undefined` can be returned to remove an item from the resulting array. In ECMAScript, and this DataTables method, those values are used in the new instance.
 

--- a/docs/api/pluck().xml
+++ b/docs/api/pluck().xml
@@ -18,7 +18,7 @@
 	<description>
 		When working with objects you may often find that you want an array containing just one property of the source object. This typically involves writing a trivial loop to create that array, although here, that loop is performed in this method, reducing the amount of code required to a trivial function call to get the data required.
 
-		This method makes use of the fact that DataTables API objects are "array like", in that they inherent a lot of the abilities and methods of the Javascript `Array` type.
+		This method makes use of the fact that DataTables API objects are "array like", in that they inherit a lot of the abilities and methods of the Javascript `Array` type.
 	</description>
 
 	<example title="Pluck the name property from the data objects for the table rows"><![CDATA[

--- a/docs/api/reverse().xml
+++ b/docs/api/reverse().xml
@@ -13,7 +13,7 @@
 	<description>
 		This method will quite simply take the elements in an API instance's result set and reverse the order of those element, in place. This is particularly used when used with the `dt-api sort()` method.
 
-		This method makes use of the fact that DataTables API objects are "array like", in that they inherent a lot of the abilities and methods of the Javascript `Array` type.
+		This method makes use of the fact that DataTables API objects are "array like", in that they inherit a lot of the abilities and methods of the Javascript `Array` type.
 
 		In this case, this method is a proxy for the Javascript `Array.prototype.reverse` method and is provided as a utility method for the DataTables API. For more information about the original method, please refer to the [Mozilla MDN documentation for `reverse`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/reverse).
 	</description>

--- a/docs/api/sort().xml
+++ b/docs/api/sort().xml
@@ -21,7 +21,7 @@
 	<description>
 		The `dt-api sort()` method provides a way of sorted the data in an API instance's result set, which can be particularly useful if you then want to use that data for displaying to the end user - for example as a `dt-tag select` list for a search input. This method should not be confused with `dt-api order()` which is used to order for records in the DataTable.
 
-		This method makes use of the fact that DataTables API objects are "array like", in that they inherent a lot of the abilities and methods of the Javascript `Array` type.
+		This method makes use of the fact that DataTables API objects are "array like", in that they inherit a lot of the abilities and methods of the Javascript `Array` type.
 
 		In this case, this method is a proxy for the Javascript `Array.prototype.sort` method and is provided as a utility method for the DataTables API. For more information about the original method, please refer to the [Mozilla MDN documentation for `sort`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort).
 	</description>

--- a/docs/api/splice().xml
+++ b/docs/api/splice().xml
@@ -22,7 +22,7 @@
 	<description>
 		The methods of `dt-api pop()`, `dt-api shift()` etc can be useful to modify an Api instance's result set, but they are restricted to operating at the start of the end of the result set. This method can be used to modify the result set at any point.
 
-		This method makes use of the fact that DataTables API objects are "array like", in that they inherent a lot of the abilities and methods of the Javascript `Array` type.
+		This method makes use of the fact that DataTables API objects are "array like", in that they inherit a lot of the abilities and methods of the Javascript `Array` type.
 
 		In this case, this method is a proxy for the Javascript `Array.prototype.splice` method and is provided as a utility method for the DataTables API. For more information about the original method, please refer to the [Mozilla MDN documentation for `splice`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/splice).
 	</description>

--- a/docs/api/toArray().xml
+++ b/docs/api/toArray().xml
@@ -13,7 +13,7 @@
 	<description>
 		The DataTables API object provides a lot of the methods that you would expect to find in a native Javascript array and generally acts a lot like an array, but there are times when you want to work directly with a Javascript array rather than a DataTables API instance. This method can be used to create a native Javascript array which contains the same items as contained in the API instance's result set.
 
-		This method makes use of the fact that DataTables API objects are "array like", in that they inherent a lot of the abilities and methods of the Javascript `Array` type.
+		This method makes use of the fact that DataTables API objects are "array like", in that they inherit a lot of the abilities and methods of the Javascript `Array` type.
 	</description>
 
 	<example title="Get a plain array of data from a column"><![CDATA[

--- a/docs/api/unique().xml
+++ b/docs/api/unique().xml
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <dt-api group="utility">
 	<name>unique()</name>
-	<summary>Create a new API instance containing only the unique items from a the elements in an instance's result set.</summary>
+	<summary>Create a new API instance containing only the unique items from the elements in an instance's result set.</summary>
 	<since>1.10</since>
 
 	<type type="function">
 		<signature>unique()</signature>
-		<description>Create a new API instance containing only the unique items from a the elements in an instance's result set.</description>
+		<description>Create a new API instance containing only the unique items from the elements in an instance's result set.</description>
 		<returns type="DataTables.Api">New Api instance which contains the unique items from the original instance's result set, in its own result set.</returns>
 	</type>
 
 	<description>
 		It is often useful to know what data is available in a result set, with duplicate items removed (for example creating a `dt-tag select` list for use as a search input). Although unique items can be found quite trivially with a loop, this utility function provides that ability for you in one simple method.
 
-		This method makes use of the fact that DataTables API objects are "array like", in that they inherent a lot of the abilities and methods of the Javascript `Array` type.
+		This method makes use of the fact that DataTables API objects are "array like", in that they inherit a lot of the abilities and methods of the Javascript `Array` type.
 	</description>
 
 	<example title="Get the unique data from a column"><![CDATA[

--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -1219,7 +1219,7 @@ export interface Api<T=any> {
     trigger( name: string, args: any[], bubbles?: boolean): Api<T>;
 
     /**
-     * Create a new API instance containing only the unique items from a the elements in an instance's result set.
+     * Create a new API instance containing only the unique items from the elements in an instance's result set.
      * 
      * @returns New Api instance which contains the unique items from the original instance's result set, in its own result set.
      */


### PR DESCRIPTION
- "they inherent" -> "the inherit"
- "from a the elements" -> "from the elements"