### PR TITLE
Fix issue where an empty data set continues to display "Loading..." message

### DIFF
--- a/js/core/core.draw.js
+++ b/js/core/core.draw.js
@@ -494,7 +494,7 @@ function _emptyRow ( settings ) {
 	var zero = oLang.sZeroRecords;
 	var dataSrc = _fnDataSource( settings );
 
-    if ( settings.iDraw  < 1 && settings.fnRecordsTotal() === 0 && (dataSrc === 'ajax' || dataSrc === 'ssp') )
+    if ( settings.iDraw  < 1 && (dataSrc === 'ajax' || dataSrc === 'ssp') )
 	{
 		zero = oLang.sLoadingRecords;
 	}

--- a/js/core/core.draw.js
+++ b/js/core/core.draw.js
@@ -494,7 +494,7 @@ function _emptyRow ( settings ) {
 	var zero = oLang.sZeroRecords;
 	var dataSrc = _fnDataSource( settings );
 
-	if ( settings.iDraw <= 1 && (dataSrc === 'ajax' || dataSrc === 'ssp') )
+    if ( settings.iDraw >= 1 && settings.fnRecordsTotal() > 0 && (dataSrc === 'ajax' || dataSrc === 'ssp') )
 	{
 		zero = oLang.sLoadingRecords;
 	}

--- a/js/core/core.draw.js
+++ b/js/core/core.draw.js
@@ -494,7 +494,7 @@ function _emptyRow ( settings ) {
 	var zero = oLang.sZeroRecords;
 	var dataSrc = _fnDataSource( settings );
 
-    if ( settings.iDraw >= 1 && settings.fnRecordsTotal() > 0 && (dataSrc === 'ajax' || dataSrc === 'ssp') )
+    if ( settings.iDraw  < 1 && settings.fnRecordsTotal() === 0 && (dataSrc === 'ajax' || dataSrc === 'ssp') )
 	{
 		zero = oLang.sLoadingRecords;
 	}


### PR DESCRIPTION
Hello,

I ran into an issue when I returned an empty record set from using server-side processing (SSP).  In these instances, the table continued to display "Loading..." instead of the empty message "No data available in table."  

I stepped through the code and it appeared the issue lie with the _emptyRow method located in the /js/core/core.draw.js source file.  

When the data table initially loads, the value of iDraw is 0 and the number of records for the table should be 0, so we display the loading message.  On the next pass through _emptyRow, iDraw should be 1 (or greater) and the number of records should be 0, so we should display the empty table message.

I'm sorry if I messed this up.  I'm relatively new to making pull requests.