### PR TITLE
Fix indexOf on null in search.js

### DIFF
--- a/js/features/features.search.js
+++ b/js/features/features.search.js
@@ -18,7 +18,7 @@ DataTable.feature.register( 'search', function ( settings, opts ) {
 
 	opts = $.extend({
 		placeholder: language.sSearchPlaceholder,
-		text: language.sSearch
+		text: language.sSearch || '',
 	}, opts);
 
 	// The _INPUT_ is optional - is appended if not present


### PR DESCRIPTION
Hi @AllanJard,

I'm getting an error
```
jquery.js:3793 Uncaught TypeError: Cannot read properties of null (reading 'indexOf')
    at dataTables.mjs:13089:1
    at getFeature (dataTables.mjs:3573:1)
    at resolve (dataTables.mjs:3584:1)
    at Object.<anonymous> (dataTables.mjs:3605:1)
    at Function.each (jquery.js:389:1)
    at _layoutResolve (dataTables.mjs:3604:1)
    at _layoutArray (dataTables.mjs:3552:1)
    at _fnAddOptionsHtml (dataTables.mjs:3630:1)
    at _fnInitialise (dataTables.mjs:4557:1)
    at loadedInit (dataTables.mjs:439:1)
```

this is because of the line 
https://github.com/DataTables/DataTablesSrc/blob/24c79d2f232fb75a70862fa7208fa30d7a9e61fd/js/features/features.search.js#L25

I know nothing about this plugin, and dunno what `language.sSearch` is supposed to be but seems like it can be null.

Adding `|| ''` avoid the issue.