### PR TITLE
Performance: Do not apply sort when there is only one match

### DIFF
--- a/js/core/core.sort.js
+++ b/js/core/core.sort.js
@@ -78,6 +78,10 @@ function _fnSortAttachListener(settings, node, selector, column, callback) {
  * @param {*} settings
  */
 function _fnSortDisplay(settings, display) {
+	if (display.length < 2) {
+		return;
+	}
+
 	var master = settings.aiDisplayMaster;
 	var masterMap = {};
 	var map = {};


### PR DESCRIPTION
This shaves off ~100ms when calling `rows(.., {order: 'index'})` on a table with 10k rows because each row goes through selector stuff.

EDIT: Saves over a second when not using `order` option (so it uses current).

Before:
![image](https://github.com/DataTables/DataTablesSrc/assets/613331/845c248f-f7a6-4cc4-a6c1-cd1728a43a4e)

After:
![image](https://github.com/DataTables/DataTablesSrc/assets/613331/3a5c4f49-2fb6-4c71-b1ca-6e5f72a2fc93)

This may be showing that there's some performance issue in iterating over `rows()` in general as it goes through all the selector and sorting shenanings for every row.