### PR TITLE
Selector row indexes: should return same range when SSP regardless of…

### DIFF
--- a/js/api/api.selectors.js
+++ b/js/api/api.selectors.js
@@ -100,6 +100,16 @@ var _selector_row_indexes = function ( settings, opts )
 		order  = opts.order,   // applied, current, index (original - compatibility with 1.9)
 		page   = opts.page;    // all, current
 
+	if ( _fnDataSource( settings ) == 'ssp' ) {
+		// In server-side processing mode, most options are irrelevant since
+		// rows not shown don't exist and the index order is the applied order
+		// Removed is a special case - for consistency just return an empty
+		// array
+		return search === 'removed' ?
+			[] :
+			_range( 0, displayMaster.length );
+	}
+
 	if ( page == 'current' ) {
 		// Current page implies that order=current and filter=applied, since it is
 		// fairly senseless otherwise, regardless of what order and search actually


### PR DESCRIPTION
… page

Update api.selectors.js:
Fixes responsive toggle icon only showing on page 1 and not on other pages.

Example: https://live.datatables.net/rufivaga/7/edit
In this example, the toggle in column 1 is only visible on page 1, but should also be visible on other pages.
This PR fixes this issue. 