### PR TITLE
Bootstrap3 col-xs support

### DIFF
--- a/css/dataTables.bootstrap.scss
+++ b/css/dataTables.bootstrap.scss
@@ -142,12 +142,6 @@ div.dt-scroll-foot {
 // Responsive
 @media screen and (max-width: 767px) {
 	div.dt-container {
-		div.dt-length,
-		div.dt-search,
-		div.dt-info,
-		div.dt-paging {
-			text-align: center;
-		}
 
 		div.row {
 			margin-bottom: 0;

--- a/js/integration/dataTables.bootstrap.js
+++ b/js/integration/dataTables.bootstrap.js
@@ -69,18 +69,18 @@ DataTable.ext.renderer.layout.bootstrap = function ( settings, container, items 
 	$.each( items, function (key, val) {
 		var klass = '';
 		if ( key === 'start' ) {
-			klass += 'col-sm-6 text-left';
+			klass += 'col-xs-6 text-left';
 		}
 		else if ( key === 'end' ) {
-			klass += 'col-sm-6 text-right';
+			klass += 'col-xs-6 text-right';
 
 			// If no left element, we need to offset this one
-			if (row.find('.col-sm-6').length === 0) {
-				klass += ' col-sm-offset-6';
+			if (row.find('.col-xs-6').length === 0) {
+				klass += ' col-xs-offset-6';
 			}
 		}
 		else if ( key === 'full' ) {
-			klass += 'col-sm-12';
+			klass += 'col-xs-12';
 			if ( ! val.table ) {
 				klass += ' text-center';
 			}


### PR DESCRIPTION
In Bootstrap3,

If you do col-sm-6
it will not work properly and need to specify col-xs-6

Before:
![image](https://github.com/DataTables/DataTablesSrc/assets/6744113/282063fe-631b-4e0d-b23f-81af7af4ccd2)

After:
![image](https://github.com/DataTables/DataTablesSrc/assets/6744113/fbe98de6-bda4-432a-8e7c-c033f16f743a)
