### PR TITLE
remove utc() as default timezone for momentjs

### DIFF
--- a/js/ext/ext.helpers.js
+++ b/js/ext/ext.helpers.js
@@ -46,7 +46,7 @@ function __mldObj (d, format, locale) {
 	resolveWindowLibs();
 
 	if (__moment) {
-		dt = __moment.utc( d, format, locale, true );
+		dt = __moment( d, format, locale, true );
 
 		if (! dt.isValid()) {
 			return null;


### PR DESCRIPTION
This PR removes utc() as default setter for timestrings. At the moment, timestrings will parsed by momentjs to UTC+0. After this chnage, local time will applied. THat's the same behavor as when using luxon.

This PR fixes #289 a little bit. It's no full solution but enough for most cases.