### PR TITLE
make scrollbody focusable

### DIFF
--- a/js/core/core.scrolling.js
+++ b/js/core/core.scrolling.js
@@ -139,6 +139,8 @@ function _fnFeatureHtmlTable ( settings )
 		$(scrollBody).css('height', scrollY);
 	}
 
+	$(scrollBody).attr('tabindex', settings.iTabIndex)
+
 	settings.nScrollHead = scrollHead;
 	settings.nScrollBody = scrollBody;
 	settings.nScrollFoot = scrollFoot;


### PR DESCRIPTION
If there is a scrollable table, it would be nice to focus on the scrollbody so that we can use the keyboard to scroll.

This PR adds the tab index to the scrollbody according to the value:

https://github.com/DataTables/DataTablesSrc/blob/daa37b2f01e288acbfbff1e019cd3b9f44aeec7c/js/model/model.defaults.js#L491

Result:
![recording](https://github.com/user-attachments/assets/9f0c65ca-c4fa-48b4-a2cd-a53212302e6e)




Note: It seems to be redundant if [KeyTable Plugin](https://datatables.net/extensions/keytable/) is used, as keyboard navigation is already available for cells.
Example: https://datatables.net/extensions/keytable/examples/initialisation/scrolling.html