### PR TITLE
fix typo in the doc for columns().types()

### DIFF
--- a/docs/api/column().type().xml
+++ b/docs/api/column().type().xml
@@ -32,5 +32,5 @@ $('#example').on('click', 'tbody td', function () {
 
 	<related>-init columns.type</related>
 	<related>-api column().type()</related>
-	<related>-api columns().type()</related>
+	<related>-api columns().types()</related>
 </dt-api>

--- a/docs/api/columns().types().xml
+++ b/docs/api/columns().types().xml
@@ -29,5 +29,5 @@ console.log(
 
 	<related>-init columns.type</related>
 	<related>-api column().type()</related>
-	<related>-api columns().type()</related>
+	<related>-api columns().types()</related>
 </dt-api>

--- a/test/api/columns/columns().types().js
+++ b/test/api/columns/columns().types().js
@@ -1,4 +1,4 @@
-describe('columns- columns().type()', function() {
+describe('columns- columns().types()', function() {
 	dt.libs({
 		js: ['jquery', 'datatables'],
 		css: ['datatables']


### PR DESCRIPTION
https://datatables.net/reference/api/columns().type()
should be
https://datatables.net/reference/api/columns().types()