### PR TITLE
fix: date render helpers wrt. setting locales in Luxon

### DIFF
--- a/js/ext/ext.helpers.js
+++ b/js/ext/ext.helpers.js
@@ -61,7 +61,7 @@ function __mldObj (d, format, locale) {
 			return null;
 		}
 
-		dt.setLocale(locale);
+		dt = dt.setLocale(locale);
 	}
 	else if (! format) {
 		// No format given, must be ISO


### PR DESCRIPTION
fixes #301

Luxon works with immutable objects, so we have to override the variable with its modified copy.