### PR TITLE
Bug fixes in the server side datatables example, specifically in spp.class.php

### DIFF
--- a/examples/server_side/scripts/ssp.class.php
+++ b/examples/server_side/scripts/ssp.class.php
@@ -373,6 +373,7 @@ class SSP {
 
 				if ( isset($whereAll['bindings']) ) {
 					self::add_bindings($whereAllBindings, $whereAll['bindings']);
+					$bindings = array_merge($bindings, $whereAllBindings);
 				}
 			}
 
@@ -539,8 +540,8 @@ class SSP {
 
 	static function add_bindings(&$a, $vals)
 	{
-		foreach($vals['bindings'] as $key => $value) {
-			$bindings[] = array(
+		foreach($vals as $key => $value) {
+			$a[] = array(
 				'key' => $key,
 				'val' => $value,
 				'type' => PDO::PARAM_STR


### PR DESCRIPTION
The add bindings function contains an error that causes the binds to never be added to the array passed as a parameter, causing a SQL error when executing the statements.

In addition, in the complex function, the global bindings are not added to some statements.