### PR TITLE
Add `this` type to callback functions

### DIFF
--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -3317,38 +3317,38 @@ export type ExtTypeSettingsDetect = ((data: any, settings: InternalSettings) => 
     init?: (settings: InternalSettings, column: any, index: number) => boolean
 };
 
-type FunctionAjax = (data: object, callback: ((data: any) => void), settings: InternalSettings) => void;
+type FunctionAjax = (this: JQueryDataTables, data: object, callback: ((data: any) => void), settings: InternalSettings) => void;
 
-type FunctionAjaxData = (data: AjaxData, settings: InternalSettings) => string | object;
+type FunctionAjaxData = (this: JQueryDataTables, data: AjaxData, settings: InternalSettings) => string | object;
 
-type FunctionColumnRender = (data: any, type: any, row: any, meta: CellMetaSettings) => any;
+type FunctionColumnRender = (this: JQueryDataTables, data: any, type: any, row: any, meta: CellMetaSettings) => any;
 
-type FunctionColumnCreatedCell = (cell: HTMLTableCellElement, cellData: any, rowData: any, row: number, col: number) => void;
+type FunctionColumnCreatedCell = (this: JQueryDataTables, cell: HTMLTableCellElement, cellData: any, rowData: any, row: number, col: number) => void;
 
-type FunctionCreateRow = (row: HTMLTableRowElement, data: any[] | object, dataIndex: number, cells: HTMLTableCellElement[]) => void;
+type FunctionCreateRow = (this: JQueryDataTables, row: HTMLTableRowElement, data: any[] | object, dataIndex: number, cells: HTMLTableCellElement[]) => void;
 
-type FunctionDrawCallback = (settings: InternalSettings) => void;
+type FunctionDrawCallback = (this: JQueryDataTables, settings: InternalSettings) => void;
 
-type FunctionFooterCallback = (tr: HTMLTableRowElement, data: any[], start: number, end: number, display: any[]) => void;
+type FunctionFooterCallback = (this: JQueryDataTables, tr: HTMLTableRowElement, data: any[], start: number, end: number, display: any[]) => void;
 
-type FunctionFormatNumber = (formatNumber: number) => void;
+type FunctionFormatNumber = (this: JQueryDataTables, formatNumber: number) => void;
 
-type FunctionHeaderCallback = (tr: HTMLTableRowElement, data: any[], start: number, end: number, display: any[]) => void;
+type FunctionHeaderCallback = (this: JQueryDataTables, tr: HTMLTableRowElement, data: any[], start: number, end: number, display: any[]) => void;
 
-type FunctionInfoCallback = (settings: InternalSettings, start: number, end: number, mnax: number, total: number, pre: string) => void;
+type FunctionInfoCallback = (this: JQueryDataTables, settings: InternalSettings, start: number, end: number, mnax: number, total: number, pre: string) => void;
 
-type FunctionInitComplete = (settings: InternalSettings, json: object) => void;
+type FunctionInitComplete = (this: JQueryDataTables, settings: InternalSettings, json: object) => void;
 
-type FunctionPreDrawCallback = (settings: InternalSettings) => void;
+type FunctionPreDrawCallback = (this: JQueryDataTables, settings: InternalSettings) => void;
 
-type FunctionRowCallback = (row: HTMLTableRowElement, data: any[] | object, index: number) => void;
+type FunctionRowCallback = (this: JQueryDataTables, row: HTMLTableRowElement, data: any[] | object, index: number) => void;
 
-type FunctionStateLoadCallback = (settings: InternalSettings, callback: ((state) => void)) => void | object;
+type FunctionStateLoadCallback = (this: JQueryDataTables, settings: InternalSettings, callback: ((state) => void)) => void | object;
 
-type FunctionStateLoaded = (settings: InternalSettings, data: object) => void;
+type FunctionStateLoaded = (this: JQueryDataTables, settings: InternalSettings, data: object) => void;
 
-type FunctionStateLoadParams = (settings: InternalSettings, data: object) => void;
+type FunctionStateLoadParams = (this: JQueryDataTables, settings: InternalSettings, data: object) => void;
 
-type FunctionStateSaveCallback = (settings: InternalSettings, data: object) => void;
+type FunctionStateSaveCallback = (this: JQueryDataTables, settings: InternalSettings, data: object) => void;
 
-type FunctionStateSaveParams = (settings: InternalSettings, data: object) => void;
+type FunctionStateSaveParams = (this: JQueryDataTables, settings: InternalSettings, data: object) => void;


### PR DESCRIPTION
Basically fixes the following:

```js
table.DataTable( {
	rowCallback( rowRaw, data, index )
	{
		const api = this.api(); // Property 'api' does not exist on type 'Config'.
	}
} );
```

I hope all the `Function*` on the bottom are used by Config, so change should be correct for all of them?