### PR TITLE
Fix possible "Maximum call stack size exceeded."

### DIFF
--- a/js/core/core.constructor.js
+++ b/js/core/core.constructor.js
@@ -239,7 +239,7 @@ _fnApplyColumnDefs( oSettings, oInit.aoColumnDefs, columnsInit, initHeaderLayout
 /* HTML5 attribute detection - build an mData object automatically if the
  * attributes are found
  */
-var rowOne = $this.children('tbody').find('tr').eq(0);
+var rowOne = $this.children('tbody').find('tr:first-child').eq(0);
 
 if ( rowOne.length ) {
 	var a = function ( cell, name ) {


### PR DESCRIPTION
I've had some mobile browsers reporting this error on some pages that had tables with upwards of 100k rows.

I've reproduced the issue on desktop chrome by making a table that had a million rows. Looking at this code, it doesn't even need to select all rows, just getting the first one is enough (maybe this selector could be improved even further).

I've created a jquery issue here: https://github.com/jquery/jquery/issues/5638