### PR TITLE
Change column ordering fallback strategy

### DIFF
--- a/js/core/core.state.js
+++ b/js/core/core.state.js
@@ -146,16 +146,19 @@ function _fnImplementState ( settings, s, callback) {
 
 			// A column name was stored and should be used for restore
 			if (typeof col[0] === 'string') {
+				// Find the name from the current list of column names
 				var idx = currentNames.indexOf(col[0]);
 
-				// Find the name from the current list of column names, or fallback to index 0
-				set[0] = idx >= 0
-					? idx
-					: 0;
+				if (idx < 0) {
+					// If the column was not found ignore it and continue
+					return;
+				}
+
+				set[0] = idx;
 			}
 			else if (set[0] >= columns.length) {
-				// If a column name, but it is out of bounds, set to 0
-				set[0] = 0;
+				// If the column index is out of bounds ignore it and continue
+				return;
 			}
 
 			settings.aaSorting.push(set);


### PR DESCRIPTION
While upgrading datatables from `1.11.5` to `2.2.2` we encountered a problem where the first column (containing only checkboxes) became ordered with indicator icon showing. This happend due to the way datatables handles data when it loads the state. In the state data there is a field `order` containing tuples `[columnName, sortDirection]`. For each tuple, DataTables tries to find the column by name and if it doesn't it falls back to index 0 and sorts that column. Even if that first column is defined to be not orderable, by setting [orderable](https://datatables.net/reference/option/columns.orderable) to `false`.

![image](https://github.com/user-attachments/assets/6c0259a7-309c-4ff5-85c9-5eafaa5870bb)

In all cases so far it was our fault because we put in bad data. But I still think this default strategy to fall back to the first column is strange and usually not what you would expect. Therefore I propose to change the fallback strategy for when no column is found for the given name to either

1. Don't do anything. Just ignore the order instruction. This is what this PR implements.
2. Fallback to the first orderable column instead of just the first one. 

If you prefer option 2 I can change the PR. I prefer option 1 since I think sorting an arbitrary column is bad strategy.

These changes can be included under the MIT license.