### PR TITLE
Fix OrderArray TS type

### DIFF
--- a/docs/type/DataTables.Order.xml
+++ b/docs/type/DataTables.Order.xml
@@ -21,7 +21,7 @@ interface OrderName {
 	dir: 'asc' | 'desc';
 }
 
-type OrderArray = [number, 'asc' | 'desc'];
+type OrderArray = [number, 'asc' | 'desc' | ''];
 
 type OrderCombined = OrderIdx | OrderName | OrderArray;
 

--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -109,7 +109,7 @@ export interface OrderName {
 	dir: 'asc' | 'desc';
 }
 
-export type OrderArray = [number, 'asc' | 'desc'];
+export type OrderArray = [number, 'asc' | 'desc' | ''];
 
 export type OrderCombined = OrderIdx | OrderName | OrderArray;
 


### PR DESCRIPTION
I used the [order API](https://datatables.net/reference/api/order()) and noticed that the result can contain empty strings and not just `'asc'` and `'desc'`. I don't know if `OrderIdx` and `OrderName` should be updated as well. I just fixed the part where I got a TS error. Let me know if I should update the two interfaces as well.

These changes can be included under the MIT license.