### PR TITLE
Update Row Grouping example to use 2D arrays

### DIFF
--- a/examples/advanced_init/row_grouping.xml
+++ b/examples/advanced_init/row_grouping.xml
@@ -50,10 +50,10 @@ var table = $('#example').DataTable({
 $('#example tbody').on('click', 'tr.group', function () {
 	var currentOrder = table.order()[0];
 	if (currentOrder[0] === groupColumn && currentOrder[1] === 'asc') {
-		table.order([groupColumn, 'desc']).draw();
+		table.order([[groupColumn, 'desc']]).draw();
 	}
 	else {
-		table.order([groupColumn, 'asc']).draw();
+		table.order([[groupColumn, 'asc']]).draw();
 	}
 });
 ]]></js>


### PR DESCRIPTION
The [Row Grouping example](https://datatables.net/examples/advanced_init/row_grouping.html) uses 1D arrays with the `order()` API which breaks the use of `var currentOrder = table.order()[0];`.  This change is to use the 2D array data structure, that is consistent with the `order` option and clicking a column header to sort, in the event handler.  This is to fix the issue found in this [thread](https://datatables.net/forums/discussion/80788/the-example-for-row-grouping-will-not-sort-descending#latest).

This contribution follows the project's existing license (MIT).