### PR TITLE
Add security fix for prototype pollution vulnerability

### DIFF
--- a/js/DataTables.js
+++ b/js/DataTables.js
@@ -1,11 +1,11 @@
-/*! DataTables 1.10.13
+/*! DataTables 1.10.13-sp1
  * ©2008-2016 SpryMedia Ltd - datatables.net/license
  */
 
 /**
  * @summary     DataTables
  * @description Paginate, search and order HTML tables
- * @version     1.10.13
+ * @version     1.10.13-sp1
  * @file        jquery.dataTables.js
  * @author      SpryMedia Ltd
  * @contact     www.datatables.net
@@ -169,7 +169,7 @@
 	 *  @type string
 	 *  @default Version number
 	 */
-	DataTable.version = "1.10.13";
+	DataTable.version = "1.10.13-sp1";
 
 	/**
 	 * Private data store, containing all of the settings objects that are

--- a/js/core/core.data.js
+++ b/js/core/core.data.js
@@ -356,6 +356,11 @@ function _fnSetObjectDataFn( mSource )
 
 			for ( var i=0, iLen=a.length-1 ; i<iLen ; i++ )
 			{
+				// Protect against prototype pollution
+				if (a[i] === '__proto__') {
+					throw new Error('Cannot set prototype values');
+				}
+
 				// Check if we are dealing with an array notation request
 				arrayNotation = a[i].match(__reArray);
 				funcNotation = a[i].match(__reFn);


### PR DESCRIPTION
This is a security patch release for DataTables 1.10.13 that addresses a prototype pollution vulnerability.

### Security Fix
- Added protection against prototype pollution attacks by preventing the use of `__proto__` in data paths
- The patch is a backport of the fix from commit [2632813d2ee433f7805f09f47a2afe6937c355ce](https://github.com/DataTables/DataTablesSrc/commit/2632813d2ee433f7805f09f47a2afe6937c355ce)

I would like this fix to be available as a patch on top of version `1.10.13` to avoid having to upgrade through all the other versions up to `1.10.22` to receive this fix.

---

Questions:

* What is your preference for the version name?

---

My contribution is offered under and will be made available under the project's existing license (MIT).