### PR TITLE
Fix: avoid superfluous neutral sort state when multi-sorting

### DIFF
--- a/js/core/core.sort.js
+++ b/js/core/core.sort.js
@@ -400,7 +400,7 @@ function _fnSortAdd ( settings, colIdx, addIndex, shift )
 				nextSortIdx = 0; // can't remove sorting completely
 			}
 
-			if ( nextSortIdx === null ) {
+			if ( nextSortIdx === null || asSorting[ nextSortIdx ] === '' ) {
 				sorting.splice( sortIdx, 1 );
 			}
 			else {


### PR DESCRIPTION
I noticed that when using shift+click to do a multi-sort, that there seemed to be two consecutive "neutral" sorting state changes, which is unexpected to me. This PR removes that extra "neutral" sorting state change.

[JSFiddle](https://jsfiddle.net/72uje8sr/)

<details>
<summary>Raw standalone HTML</summary>

```html
<!doctype html>
<html lang="en">
  <head>
    <meta charset="utf-8">
    <title>Multi-sort bug</title>
    <link href="https://cdn.datatables.net/v/dt/jq-3.7.0/dt-2.3.2/datatables.min.css" rel="stylesheet" crossorigin="anonymous">
    <script src="https://cdn.datatables.net/v/dt/jq-3.7.0/dt-2.3.2/datatables.min.js" crossorigin="anonymous"></script>
  </head>
  <body>
    <table class="display" style="width: 100%">
      <thead>
        <tr>
          <th scope="col">Col 1</th>
          <th scope="col">Col 2</th>
          <th scope="col">Col 3</th>
          <th scope="col">Col 4</th>
          <th scope="col">Col 5</th>
        </tr>
      </thead>
      <tbody class="table-group-divider"></tbody>
    </table>
    <script>
      $(() => {
        new DataTable($('table'), {
          autoWidth: true,
          columns: [
            {
              className: 'dt-head-left dt-body-left',
              data: 0,
              name: 'Col1',
              type: 'num',
            },
            {
              className: 'dt-head-left dt-body-left',
              data: 1,
              name: 'Col2',
              type: 'string',
            },
            {
              className: 'dt-head-left dt-body-left',
              data: 2,
              name: 'Col3',
              type: 'string',
            },
            {
              className: 'dt-head-left dt-body-left min-desktop',
              data: 3,
              name: 'Col4',
              type: 'string',
            },
            {
              className: 'dt-head-left dt-body-left',
              data: 4,
              name: 'Col5',
              type: 'string',
            },
          ],
          ordering: true,
        });
      });
    </script>
  </body>
</html>
```

</details>