### PR TITLE
Fix: work in xhtml files

### DIFF
--- a/js/core/core.sizing.js
+++ b/js/core/core.sizing.js
@@ -64,7 +64,7 @@ function _fnCalculateColumnWidths ( settings )
 		.removeAttr( 'id' );
 
 	// Clean up the table body
-	tmpTable.append('<tbody>')
+	tmpTable.append('<tbody/>')
 	var tr = $('<tr/>').appendTo( tmpTable.find('tbody') );
 
 	// Clone the table header and footer - we can't use the header / footer


### PR DESCRIPTION
Hi, in  [xhtml, all tags must have closing tags](https://www.w3.org/TR/xhtml1/diffs.html#:~:text=Essentially%20this%20means%20that%20all%20elements%20must%20either%20have%20closing%20tags) and DataTables creates an element that doesn't have a closing tag, thus not loading correctly in pages distributed as html. 
Even though xhtml is not used frequently, trying to debug this issue in a website that uses it is painful (don't ask me how I know), and adding a closing tag wouldn't affect users that use DataTables on regular html5 pages.
If you need any additional info, let me know