### PR TITLE
Fix: Unable to build master after variable rename

### DIFF
--- a/js/core/core.sort.js
+++ b/js/core/core.sort.js
@@ -222,7 +222,7 @@ function _fnSortFlatten ( settings )
 function _fnSort ( oSettings, col, dir )
 {
 	var
-		i, iLen, iLen,
+		i, iLen,
 		aiOrig = [],
 		extSort = DataTable.ext.type.order,
 		aoData = oSettings.aoData,


### PR DESCRIPTION
## make build work again !

Hi there! 👋

#### Problem

```bash
/datatables/DataTablesSrc/built/js/dataTables.js
  5977:13  error  'iLen' is already defined  no-redeclare

✖ 1 problem (1 error, 0 warnings)

  Lint failed 
    Updating package descriptors 
```

### Proposed Change

The build was failing due to a redeclaration of the variable iLen. This change removes the duplicate declaration, which resolves the issue and allows the build to complete successfully.

### Thanks!

Thank you for reviewing this!
Let me know if anything needs to be changed or improved.

---

I acknowledge that my contribution is offered under and will be made available under the project's existing license (MIT). ✅