### PR TITLE
add Unix parsing on luxon library

### DIFF
--- a/js/ext/ext.helpers.js
+++ b/js/ext/ext.helpers.js
@@ -53,8 +53,8 @@ function __mldObj (d, format, locale) {
 		}
 	}
 	else if (__luxon) {
-		dt = format && typeof d === 'string'
-			? __luxon.DateTime.fromFormat( d, format )
+		dt = typeof d === 'string' && format
+			? (format == 'X' ? __luxon.DateTime.fromSeconds( d ) : format == 'x' ? __luxon.DateTime.fromMillis( d ) : __luxon.DateTime.fromFormat( d, format ))
 			: __luxon.DateTime.fromISO( d );
 
 		if (! dt.isValid) {


### PR DESCRIPTION
The momentjs library can parse various strings into a time object. This includes Unix timestamps in seconds (X) and milliseconds (x). The luxon library, on the other hand, cannot parse these two formats, only format them. With this PR, parsing for Unix timestamps is added manually to maintain the same range of functions.