### PR TITLE
Add the ability to configure a column to be searchable only by the API. Addresses #210

### DIFF
--- a/docs/option/columns.searchable.xml
+++ b/docs/option/columns.searchable.xml
@@ -4,11 +4,11 @@
 	<summary>Enable or disable search on the data in this column</summary>
 	<since>1.10</since>
 
-	<type type="boolean" />
+	<type type="boolean|string" />
 	<default value="true" />
 
 	<description>
-		Using this parameter, you can define if DataTables should include this column in the filterable data in the table. You may want to use this option to disable search on generated columns such as 'Edit' and 'Delete' buttons for example.
+		Using this parameter, you can define if DataTables should include this column in the filterable data in the table. You may want to use this option to disable search on generated columns such as 'Edit' and 'Delete' buttons for example. A value of 'api' will configure the column to be searchable by the API only. This is useful in situations where a button is used to apply a filter on a certain column, however searching this column using the search input is not desired.
 	</description>
 
 	<example title="Disable search on the first column with `dt-init columnDefs`"><![CDATA[
@@ -17,11 +17,23 @@ new DataTable('#myTable', {
 });
 ]]></example>
 
+	<example title="Enable filtering on the first column for the API only with `dt-init columnDefs`"><![CDATA[
+new DataTable('#myTable', {
+	columnDefs: [{ searchable: 'api', target: 0 }]
+});
+]]></example>
+
 	<example title="Disable search on the first column with `dt-init columns`"><![CDATA[
 new DataTable('#myTable', {
 	columns: [{ searchable: false }, null, null, null, null]
 });
 ]]></example>
+
+<example title="Enable search on the first column with the API only, with `dt-init columns`"><![CDATA[
+	new DataTable('#myTable', {
+		columns: [{ searchable: 'api' }, null, null, null, null]
+	});
+	]]></example>
 
 	<related type="option">search</related>
 	<related type="api">search()</related>

--- a/js/api/api.ajax.js
+++ b/js/api/api.ajax.js
@@ -11,7 +11,7 @@ var __reload = function ( settings, holdPosition, callback ) {
 	}
 
 	if ( _fnDataSource( settings ) == 'ssp' ) {
-		_fnReDraw( settings, holdPosition );
+		_fnReDraw( settings, holdPosition, undefined, true );
 	}
 	else {
 		_fnProcessingDisplay( settings, true );
@@ -31,7 +31,7 @@ var __reload = function ( settings, holdPosition, callback ) {
 				_fnAddData( settings, data[i] );
 			}
 
-			_fnReDraw( settings, holdPosition );
+			_fnReDraw( settings, holdPosition, undefined, true );
 			_fnInitComplete( settings );
 			_fnProcessingDisplay( settings, false );
 		} );

--- a/js/api/api.draw.js
+++ b/js/api/api.draw.js
@@ -15,7 +15,7 @@ _api_register( 'draw()', function ( paging ) {
 					true;
 			}
 
-			_fnReDraw( settings, paging===false );
+			_fnReDraw( settings, paging===false, undefined, true );
 		}
 	} );
 } );

--- a/js/api/api.search.js
+++ b/js/api/api.search.js
@@ -20,7 +20,7 @@ _api_register( 'search()', function ( input, regex, smart, caseInsen ) {
 			// New style options to pass to the search builder
 			_fnFilterComplete( settings, $.extend( settings.oPreviousSearch, regex, {
 				search: input
-			} ) );
+			} ), true );
 		}
 		else {
 			// Compat for the old options
@@ -29,7 +29,7 @@ _api_register( 'search()', function ( input, regex, smart, caseInsen ) {
 				regex:  regex === null ? false : regex,
 				smart:  smart === null ? true  : smart,
 				caseInsensitive: caseInsen === null ? true : caseInsen
-			} ) );
+			} ), true );
 		}
 	} );
 } );
@@ -92,7 +92,7 @@ _api_registerPlural(
 				} );
 			}
 
-			_fnFilterComplete( settings, settings.oPreviousSearch );
+			_fnFilterComplete( settings, settings.oPreviousSearch, true );
 		} );
 	}
 );

--- a/js/core/core.ajax.js
+++ b/js/core/core.ajax.js
@@ -165,7 +165,7 @@ function _fnAjaxParameters(settings) {
 			return {
 				data: colData(i, 'mData'),
 				name: column.sName,
-				searchable: column.bSearchable,
+				searchable: column.bsSearchable,
 				orderable: column.bSortable,
 				search: {
 					value: preColSearch[i].search,

--- a/js/core/core.columns.js
+++ b/js/core/core.columns.js
@@ -30,7 +30,7 @@ function _fnAddColumn( oSettings )
  * Apply options for a column
  *  @param {object} oSettings dataTables settings object
  *  @param {int} iCol column index to consider
- *  @param {object} oOptions object with sType, bVisible and bSearchable etc
+ *  @param {object} oOptions object with sType, bVisible and bsSearchable etc
  *  @memberof DataTable#oApi
  */
 function _fnColumnOptions( oSettings, iCol, oOptions )
@@ -236,7 +236,7 @@ function _fnVisibleColumns( settings )
  * Get an array of column indexes that match a given property
  *  @param {object} oSettings dataTables settings object
  *  @param {string} sParam Parameter in aoColumns to look for - typically
- *    bVisible or bSearchable
+ *  bVisible or bsSearchable
  *  @returns {array} Array of indexes with matched properties
  *  @memberof DataTable#oApi
  */

--- a/js/core/core.compat.js
+++ b/js/core/core.compat.js
@@ -10,7 +10,7 @@
 function _fnHungarianMap ( o )
 {
 	var
-		hungarian = 'a aa ai ao as b fn i m o s ',
+		hungarian = 'a aa ai ao as b bs fn i m o s ',
 		match,
 		newKey,
 		map = {};

--- a/js/core/core.draw.js
+++ b/js/core/core.draw.js
@@ -488,9 +488,10 @@ function _fnDraw( oSettings, ajaxComplete )
  *  @param {object} oSettings dataTables settings object
  *  @param {boolean} [holdPosition] Keep the current paging position. By default
  *    the paging is reset to the first page
+ *  @param {bool} fromApi Whether this function was invoked by the API
  *  @memberof DataTable#oApi
  */
-function _fnReDraw( settings, holdPosition, recompute )
+function _fnReDraw( settings, holdPosition, recompute, fromApi )
 {
 	var
 		features = settings.oFeatures,
@@ -506,7 +507,7 @@ function _fnReDraw( settings, holdPosition, recompute )
 		}
 
 		if ( filter ) {
-			_fnFilterComplete( settings, settings.oPreviousSearch );
+			_fnFilterComplete( settings, settings.oPreviousSearch, fromApi );
 		}
 		else {
 			// No filtering, so we want to just use the display master

--- a/js/core/core.filter.js
+++ b/js/core/core.filter.js
@@ -4,9 +4,10 @@
  * Filter the table using both the global filter and column based filtering
  *  @param {object} settings dataTables settings object
  *  @param {object} input search information
+ *  @param {bool} fromApi Whether this function was invoked by the API
  *  @memberof DataTable#oApi
  */
-function _fnFilterComplete ( settings, input )
+function _fnFilterComplete ( settings, input, fromApi )
 {
 	var columnsSearch = settings.aoPreSearchCols;
 
@@ -20,10 +21,10 @@ function _fnFilterComplete ( settings, input )
 		settings.aiDisplay = settings.aiDisplayMaster.slice();
 
 		// Global filter first
-		_fnFilter( settings.aiDisplay, settings, input.search, input );
+		_fnFilter( settings.aiDisplay, settings, input.search, input, undefined, fromApi );
 
 		$.each(settings.searchFixed, function (name, term) {
-			_fnFilter(settings.aiDisplay, settings, term, {});
+			_fnFilter(settings.aiDisplay, settings, term, {}, undefined, fromApi );
 		});
 
 		// Then individual column filters
@@ -36,11 +37,12 @@ function _fnFilterComplete ( settings, input )
 				settings,
 				col.search,
 				col,
-				i
+				i,
+				fromApi
 			);
 
 			$.each(settings.aoColumns[i].searchFixed, function (name, term) {
-				_fnFilter(settings.aiDisplay, settings, term, {}, i);
+				_fnFilter(settings.aiDisplay, settings, term, {}, i, fromApi);
 			});
 		}
 
@@ -93,7 +95,7 @@ function _fnFilterCustom( settings )
 /**
  * Filter the data table based on user input and draw the table
  */
-function _fnFilter( searchRows, settings, input, options, column )
+function _fnFilter( searchRows, settings, input, options, column, fromApi )
 {
 	if ( input === '' ) {
 		return;
@@ -115,8 +117,10 @@ function _fnFilter( searchRows, settings, input, options, column )
 	for (i=0 ; i<searchRows.length ; i++) {
 		var row = settings.aoData[ searchRows[i] ];
 		var data = column === undefined
-			? row._sFilterRow
-			: row._aFilterData[ column ];
+			? fromApi ? row._sFilterRow
+				: row._sFilterRowWithoutApi
+			: fromApi ? row._aFilterData[ column ]
+				: row._aFilterDataWithoutApi[ column ];
 
 		if ( (searchFunc && searchFunc(data, row._aData, searchRows[i], column)) || (rpSearch && rpSearch.test(data)) ) {
 			matched.push(searchRows[i]);
@@ -247,7 +251,7 @@ function _fnFilterData ( settings )
 	var columns = settings.aoColumns;
 	var data = settings.aoData;
 	var column;
-	var j, jen, filterData, cellData, row;
+	var j, jen, filterData, filterDataWithoutApi, cellData, row;
 	var wasInvalidated = false;
 
 	for ( var rowIdx=0 ; rowIdx<data.length ; rowIdx++ ) {
@@ -257,13 +261,14 @@ function _fnFilterData ( settings )
 
 		row = data[rowIdx];
 
-		if ( ! row._aFilterData ) {
+		if ( ! row._aFilterData || ! row._aFilterDataWithoutApi) {
 			filterData = [];
+			filterDataWithoutApi = [];
 
 			for ( j=0, jen=columns.length ; j<jen ; j++ ) {
 				column = columns[j];
 
-				if ( column.bSearchable ) {
+				if ( column.bsSearchable === true || column.bsSearchable === "api" ) {
 					cellData = _fnGetCellData( settings, rowIdx, j, 'filter' );
 
 					// Search in DataTables is string based
@@ -295,10 +300,22 @@ function _fnFilterData ( settings )
 				}
 
 				filterData.push( cellData );
+
+				// If this column is searchable by the API only, push
+				// a blank string to preserve array indexing.
+				if ( column.bsSearchable === 'api' ) {
+					filterDataWithoutApi.push( '' );
+				} else {
+					filterDataWithoutApi.push( cellData );
+				}
 			}
 
 			row._aFilterData = filterData;
 			row._sFilterRow = filterData.join('  ');
+
+			row._aFilterDataWithoutApi = filterDataWithoutApi;
+			row._sFilterRowWithoutApi = filterDataWithoutApi.join('  ');
+
 			wasInvalidated = true;
 		}
 	}

--- a/js/core/core.init.js
+++ b/js/core/core.init.js
@@ -61,7 +61,7 @@ function _fnInitialise ( settings )
 		// will do the drawing for us. Otherwise we draw the table regardless of the
 		// Ajax source - this allows the table to look initialised for Ajax sourcing
 		// data (show 'loading' message possibly)
-		_fnReDraw( settings );
+		_fnReDraw( settings, undefined, undefined, true );
 
 		// Server-side processing init complete is done by _fnAjaxUpdateDraw
 		if ( dataSrc != 'ssp' || deferLoading ) {
@@ -80,7 +80,7 @@ function _fnInitialise ( settings )
 					// it appear 'fresh'
 					settings.iInitDisplayStart = iAjaxStart;
 
-					_fnReDraw( settings );
+					_fnReDraw( settings, undefined, undefined, true );
 					_fnProcessingDisplay( settings, false );
 					_fnInitComplete( settings );
 				}, settings );

--- a/js/core/core.sort.js
+++ b/js/core/core.sort.js
@@ -66,7 +66,7 @@ function _fnSortAttachListener(settings, node, selector, column, callback) {
 					_fnSort( settings );
 					_fnSortDisplay( settings, settings.aiDisplay );
 
-					_fnReDraw( settings, false, false );
+					_fnReDraw( settings, false, false, true );
 
 					if (callback) {
 						callback();

--- a/js/features/features.search.js
+++ b/js/features/features.search.js
@@ -65,7 +65,7 @@ DataTable.feature.register( 'search', function ( settings, opts ) {
 			_fnProcessingRun(settings, opts.processing, function () {
 				previousSearch.search = val;
 		
-				_fnFilterComplete( settings, previousSearch );
+				_fnFilterComplete( settings, previousSearch, false );
 		
 				// Need to redraw, without resorting
 				settings._iDisplayStart = 0;

--- a/js/model/model.column.js
+++ b/js/model/model.column.js
@@ -37,10 +37,11 @@ DataTable.models.oColumn = {
 	"asSorting": null,
 
 	/**
-	 * Flag to indicate if the column is searchable, and thus should be included
-	 * in the filtering or not.
+	 * Indicates if the column is searchable, and thus should be included
+	 * in the filtering or not. Possible values are true, false or 'api'.
+	 * If the value is 'api', this column can only be searched by the API.
 	 */
-	"bSearchable": null,
+	"bsSearchable": null,
 
 	/**
 	 * Flag to indicate if the column is sortable or not.

--- a/js/model/model.defaults.columns.js
+++ b/js/model/model.defaults.columns.js
@@ -32,9 +32,10 @@ DataTable.defaults.column = {
 
 
 	/**
-	 * Enable or disable filtering on the data in this column.
+	 * Enable or disable filtering on the data in this column. A value of
+	 * "api" enables this column to be searched via the API only.
 	 */
-	"bSearchable": true,
+	"bsSearchable": true,
 
 
 	/**

--- a/js/model/model.row.js
+++ b/js/model/model.row.js
@@ -41,9 +41,22 @@ DataTable.models.oRow = {
 
 	/**
 	 * Per cell filtering data cache. As per the sort data cache, used to
-	 * increase the performance of the filtering in DataTables
+	 * increase the performance of the filtering in DataTables. The data
+	 * added to this filter can be searched by the search feature as well
+	 * as the API
 	 */
 	"_aFilterData": null,
+
+	/**
+	 * Per cell filtering data cache. As per the sort data cache, used to
+	 * increase the performance of the filtering in DataTables. Unlike
+	 * _aFilterData, the data in this filter is only visible to the
+	 * search feature
+	 *  @type array
+	 *  @default null
+	 *  @private
+	 */
+	"_aFilterDataWithoutApi": null,
 
 	/**
 	 * Filtering data cache. This is the same as the cell filtering cache, but
@@ -52,6 +65,16 @@ DataTable.models.oRow = {
 	 * needed on every search (memory traded for performance)
 	 */
 	"_sFilterRow": null,
+
+	/**
+	 * Filtering data cache. This is the same as the cell filtering cache, but
+	 * in this case a string rather than an array. This is easily computed with
+	 * a join on `_aFilterDataWithoutApi`, but is provided as a cache so the
+	 * join isn't needed on every search (memory traded for performance). This
+	 * contains filter data from columns that can only be searched by the search
+	 * feature
+	 */
+	"_sFilterRowWithoutApi": null,
 
 	/**
 	 * Denote if the original data source was from the DOM, or the data source

--- a/test/options/columns/columns_searchable.js
+++ b/test/options/columns/columns_searchable.js
@@ -7,7 +7,7 @@ describe('columns.searchable option', function() {
 	describe('Check the defaults', function() {
 		function isSearchableCorrect(expected) {
 			for (i = 0; i < 6; i++) {
-				if (expected[i] !== table.settings()[0].aoColumns[i].bSearchable) {
+				if (expected[i] !== table.settings()[0].aoColumns[i].bsSearchable) {
 					return false;
 				}
 			}
@@ -64,5 +64,30 @@ describe('columns.searchable option', function() {
 			expect($('#example tbody tr:eq(0) td:eq(0)').text()).toBe('No matching records found');
 			expect(isSearchableCorrect([false, false, false, false, false, false])).toBe(true);
 		});
+
+		dt.html('basic');
+		it('Enable searching on multiple columns for the API only', function() {
+			table = $('#example').DataTable({
+				columns: [null, { searchable: 'api' }, { searchable: 'api' }, null, null, null]
+			});
+			table.search('Accountant').draw();
+			expect($('#example tbody tr:eq(0) td:eq(0)').text()).toBe('Airi Satou');
+			expect(isSearchableCorrect([true, 'api', 'api', true, true, true])).toBe(true);
+		});
+		it('Filter on second column enabled for the API only', function() {
+			table.search('tokyo').draw();
+			expect($('#example tbody tr:eq(0) td:eq(0)').text()).toBe('Airi Satou');
+		});
+
+		dt.html('basic');
+		it('Enable all columns for the API only using columnDefs', function() {
+			table = $('#example').DataTable({
+				columnDefs: [{ searchable: 'api', targets: '_all' }]
+			});
+			table.search('a').draw();
+			expect($('#example tbody tr:eq(0) td:eq(0)').text()).toBe('Airi Satou');
+			expect(isSearchableCorrect(['api', 'api', 'api', 'api', 'api', 'api'])).toBe(true);
+		});
+
 	});
 });

--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -744,9 +744,9 @@ export interface ConfigColumns {
     render?: number | string | ObjectColumnData | FunctionColumnRender | ObjectColumnRender;
 
     /**
-     * Enable or disable filtering on the data in this column.
+     * Enable, disable or set API-only filtering on the data in this column.
      */
-    searchable?: boolean;
+    searchable?: boolean | string;
 
     /**
      * Set the column title.
@@ -3086,7 +3086,7 @@ export interface AjaxDataOrder {
 export interface AjaxDataColumn {
     data: string | number;
     name: string;
-    searchable: boolean;
+    searchable: boolean | string;
     orderable: boolean;
     search: AjaxDataSearch;
 }


### PR DESCRIPTION
This PR adds the ability to configure a column to be searchable only by the API. There may be a situation such as when a table contains a certain column for display purposes only, however there is a separate filter button or checkbox that is used to perform a search on that column. An example would be a list of employees at a company, a subset of which are eligible for promotion. Their eligibility is displayed in a column with the words "Yes" or "No." When using the search feature to search the table, if the first or last name of someone contains the letters "y", "e", "s", "n" or "o", we may not want the eligibility column to be used in the search. However, if we would like to quickly display the eligible employees using a button or checkbox for such purposes, we would need the column to be searchable by the API.

You can find a proof-of-concept [here](https://files.codespeak.org/projects/dt_pr/eligibleEmployees.htm).

This PR adds a new value for the `searchable` column property in the DataTable settings object. For a table with ID `myTable` with 3 columns, if you would like the second column to be searchable by the API only, you would need to do something like the following when initializing a datatable:

```javascript
new DataTable('#myTable', {
    columnDefs: [{ searchable: 'api', targets: 1 }]
});
```

A new filter cache has been added for column data that is searchable by the search feature as well as the API. This is because when a search is performed by the API, all searchable column data is available to search. When a search is performed with the search feature, column data available only to the API cannot be searched. Therefore, two filter caches need to be used.

The following code using a ternary operator was done for consistency sake although there doesn't appear to be a situation where a specific column is searched using the search feature. I'll let you decide if such code should stay or if I should change it to use `row.aFilterData[ column ]` exclusively

<img width="453" height="215" alt="image" src="https://github.com/user-attachments/assets/59d68e53-31df-4b86-b7a8-67a98f8cada6" />


I acknowledge that my contribution will be licensed under the MIT license.