### PR TITLE
Fix row details state restore: unescape escaped colons in row IDs

### DIFF
--- a/js/api/row.details.ts
+++ b/js/api/row.details.ts
@@ -48,6 +48,10 @@ function detailsStateLoad(api: ApiType, state: StateLoad | null) {
 				// already escaped characters.
 				return id.replace(/([^:\\]*(?:\\.[^:\\]*)*):/g, '$1\\:');
 			})
+			.map(function (id) {
+				// Unescape escaped colons for the selector
+				return id.replace(/\\:/g, ':');
+			})
 		).every(function () {
 			callbackFire(api.settings()[0], null, 'requestChild', [this]);
 		});


### PR DESCRIPTION
Fixed a bug in state restoration of child rows where colons in row IDs were not being unescaped after being escaped during state saving. The original code only escaped colons on save but did not unescape on load, causing the state to fail to restore child rows for IDs containing colons (e.g., 'a:b'). Added the reverse operation in detailsStateLoad to unescape the colon before passing to rows().