### PR TITLE
Run non-jQuery tests without jQuery

### DIFF
--- a/test/html-loader-lib.js
+++ b/test/html-loader-lib.js
@@ -50,11 +50,13 @@
 		// CHeck if everything is loaded
 		if (queue.length === 0) {
 			// Add a jQuery function to trigger native event handlers
-			window.$.fn.triggerNative = function (type) {
-				return this.each(function() {
-					this.dispatchEvent(new CustomEvent(type));
-				});
-			};
+			if (window.$) {
+				window.$.fn.triggerNative = function (type) {
+					return this.each(function() {
+						this.dispatchEvent(new CustomEvent(type));
+					});
+				};
+			}
 
 			done();
 		} else {
@@ -190,6 +192,15 @@
 		xhr.send();
 	}
 
+	function _removeElement(el) {
+		if (window.$) {
+			$(el).remove();
+		}
+		else {
+			el.remove();
+		}
+	}
+
 	// Publicly exposed method
 	window.dt = {
 		libs: function (obj) {
@@ -228,7 +239,7 @@
 		},
 
 		clean: function () {
-			if (window.$ && $.fn.dataTableSettings) {
+			if (window.DataTable && DataTable.settings) {
 				// If there are any DataTables, destroy them.
 				while(DataTable.settings.length) {
 					new DataTable.Api(DataTable.settings[0]).destroy();
@@ -236,29 +247,23 @@
 			}
 
 			var el = document.getElementById('dt-test-loader-container');
-			if (el && window.$) {
-				$(el).remove(); // jQuery to nuke events
-			} else if (el) {
-				document.body.removeChild(el);
+			if (el) {
+				_removeElement(el);
 			}
 
 			// Tidy up FixedHeader since it inserts elements into the body, rather than the container element
 			document.querySelectorAll('table.fixedHeader-floating').forEach((el) => {
-				el.parentNode.removeChild(el);
+				_removeElement(el);
 			});
 
 			// Tidy up DateTime elements as it inserts elements into the body, rather than the container element
 			document.querySelectorAll('div.dt-datetime').forEach((el) => {
-				document.body.removeChild(el);
+				_removeElement(el);
 			});
 
-			if (window.$ && $.fn.dataTableSettings && $.fn.dataTableSettings.length) {
-				$.fn.dataTableSettings.length = 0;
-			}
-
 			// Remove the detected browser settings so they can be recomputed
-			if (window.$ && $.fn.dataTable) {
-				$.fn.dataTable.__browser.barWidth = -1;
+			if (window.DataTable) {
+				DataTable.__browser.barWidth = -1;
 			}
 
 			dt.scrollTop(0);
@@ -267,7 +272,7 @@
 		},
 
 		container: function () {
-			return $('#dt-test-loader-container');
+			return DataTable.Dom.s('#dt-test-loader-container');
 		},
 
 		/*

--- a/test/nonjQuery/ajax.js
+++ b/test/nonjQuery/ajax.js
@@ -1,7 +1,13 @@
 describe('nonjQuery - ajax', function () {
 	dt.libs({
-		js: ['jquery', 'datatables'],
+		js: ['datatables'],
 		css: ['datatables']
+	});
+
+	it('Runs without jQuery', function () {
+		expect(window.jQuery).toBeUndefined();
+		expect(window.$).toBeUndefined();
+		expect(DataTable.use('jq')).toBe(null);
 	});
 
 	dt.html('basic');
@@ -22,7 +28,7 @@ describe('nonjQuery - ajax', function () {
 			],
 			initComplete: function() {
 				expect(table.rows().count()).toBe(57);
-				expect($('tbody tr').length).toBe(10);
+				expect(DataTable.Dom.s('#example tbody tr').length).toBe(10);
 				done();
 			}
 		});
@@ -47,7 +53,7 @@ describe('nonjQuery - ajax', function () {
 			paging: false,
 			initComplete: function() {
 				expect(table.rows().count()).toBe(57);
-				expect($('tbody tr').length).toBe(57);
+				expect(DataTable.Dom.s('#example tbody tr').length).toBe(57);
 				done();
 			}
 		});

--- a/test/nonjQuery/events.js
+++ b/test/nonjQuery/events.js
@@ -1,7 +1,13 @@
 describe('nonjQuery - events', function () {
 	dt.libs({
-		js: ['jquery', 'datatables'],
+		js: ['datatables'],
 		css: ['datatables']
+	});
+
+	it('Runs without jQuery', function () {
+		expect(window.jQuery).toBeUndefined();
+		expect(window.$).toBeUndefined();
+		expect(DataTable.use('jq')).toBe(null);
 	});
 
 	let event = '';

--- a/test/nonjQuery/init.js
+++ b/test/nonjQuery/init.js
@@ -1,20 +1,26 @@
 describe('nonjQuery - init', function () {
 	dt.libs({
-		js: ['jquery', 'datatables'],
+		js: ['datatables'],
 		css: ['datatables']
+	});
+
+	it('Runs without jQuery', function () {
+		expect(window.jQuery).toBeUndefined();
+		expect(window.$).toBeUndefined();
+		expect(DataTable.use('jq')).toBe(null);
 	});
 
 	dt.html('basic');
 	it('No options', function () {
 		let table = new DataTable('#example');
 		expect(table.rows().count()).toBe(57);
-		expect($('tbody tr').length).toBe(10);
+		expect(DataTable.Dom.s('#example tbody tr').length).toBe(10);
 	});
 
 	dt.html('basic');
 	it('Options', function () {
 		let table = new DataTable('#example', {paging: false});
 		expect(table.rows().count()).toBe(57);
-		expect($('tbody tr').length).toBe(57);
+		expect(DataTable.Dom.s('#example tbody tr').length).toBe(57);
 	});
 });

--- a/test/options/features/scrollXY.js
+++ b/test/options/features/scrollXY.js
@@ -13,7 +13,7 @@ describe('scrollY / X option', function() {
 
 		it('Header follows x-scrolling', function() {
 			$('body').css('white-space', 'nowrap');
-			dt.container().css('width', 400);
+			dt.container().css('width', '400px');
 			$('#example').dataTable({
 				scrollX: true,
 				scrollY: '200px',
@@ -96,7 +96,7 @@ describe('scrollY / X option', function() {
 		dt.html('basic');
 
 		it('Width of container 800px on init with scroll', function() {
-			dt.container().css('width', 800);
+			dt.container().css('width', '800px');
 			$('#example').dataTable({
 				scrollY: '300px',
 				paginate: false


### PR DESCRIPTION
Thanks for this project. We use DataTables quite a bit throughout the open-source LMS https://github.com/sakaiproject/sakai. We are hoping to move all of our various jQuery-backed table plugins to DataTables 3.0.0 without jQuery. 

For this PR, the nonjQuery tests were loading jQuery via dt.libs, so they weren't exercising the no-jQuery code path. This commit removes jQuery from those suites and updates the shared test loader to work without jquery.