### PR TITLE
Fix vanilla delegated blur handling

### DIFF
--- a/js/dom/events.ts
+++ b/js/dom/events.ts
@@ -136,7 +136,7 @@ function parseEventName(original: string | null) {
 		isFocus = true;
 	}
 	else if (name === 'blur') {
-		name = 'blurout';
+		name = 'focusout';
 		isFocus = true;
 	}
 

--- a/test/nonjQuery/events.js
+++ b/test/nonjQuery/events.js
@@ -50,4 +50,31 @@ describe('nonjQuery - events', function () {
 		expect(page).toBe(1);
 		expect(event).toBe('Page');
 	});
+
+	it('Can delegate blur events without jQuery', function () {
+		let container = document.createElement('div');
+		let input = document.createElement('input');
+		let called = 0;
+
+		container.appendChild(input);
+		document.body.appendChild(container);
+
+		try {
+			DataTable.Dom.s(container).on('blur', 'input', function (e) {
+				called++;
+				expect(this).toBe(input);
+				expect(e.currentTarget).toBe(input);
+				expect(e.delegateTarget).toBe(container);
+			});
+
+			input.dispatchEvent(new FocusEvent('focusout', { bubbles: true }));
+
+			DataTable.Dom.s(container).off('blur');
+		}
+		finally {
+			container.remove();
+		}
+
+		expect(called).toBe(1);
+	});
 });


### PR DESCRIPTION
DataTables maps non-bubbling events to bubbling equivalents for delegated handlers. `blur` was mapped to `blurout`, but the browser event is `focusout` (MDN: https://developer.mozilla.org/en-US/docs/Web/API/Element/focusout_event).

I also added a no-jQuery regression test for delegated `blur`.