### PR TITLE
Fix delegated event removal without jQuery

### DIFF
--- a/js/dom/events.ts
+++ b/js/dom/events.ts
@@ -302,7 +302,7 @@ export function remove(
 				wrapped.original === handler
 		);
 	}
-	if (eventName && selector) {
+	else if (eventName && selector) {
 		removeEvents = stored.filter(
 			wrapped =>
 				wrapped.type === eventName &&

--- a/test/nonjQuery/events.js
+++ b/test/nonjQuery/events.js
@@ -77,4 +77,38 @@ describe('nonjQuery - events', function () {
 
 		expect(called).toBe(1);
 	});
+
+	it('Removes only matching delegated event handlers without jQuery', function () {
+		let container = document.createElement('div');
+		let button = document.createElement('button');
+		let first = 0;
+		let second = 0;
+		let firstHandler = function () {
+			first++;
+		};
+		let secondHandler = function () {
+			second++;
+		};
+
+		container.appendChild(button);
+		document.body.appendChild(container);
+
+		try {
+			DataTable.Dom.s(container)
+				.on('click', 'button', firstHandler)
+				.on('click', 'button', secondHandler);
+
+			DataTable.Dom.s(container).off('click', 'button', firstHandler);
+
+			button.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+			DataTable.Dom.s(container).off('click');
+		}
+		finally {
+			container.remove();
+		}
+
+		expect(first).toBe(0);
+		expect(second).toBe(1);
+	});
 });


### PR DESCRIPTION
Fixes #394. The fix ensures `off(event, selector, handler)` in vanilla mode removes only the specified delegated handler, instead of accidentally removing every handler for that event and selector.

This contribution is offered under the DataTables project's MIT license.