### PR TITLE
Filter delegated hover events without jQuery

### DIFF
--- a/js/dom/events.ts
+++ b/js/dom/events.ts
@@ -223,6 +223,14 @@ export function add(
 				return;
 			}
 
+			if (
+				isHover &&
+				event.relatedTarget &&
+				(dTarget as Element).contains(event.relatedTarget)
+			) {
+				return;
+			}
+
 			callScope = dTarget;
 		}
 

--- a/test/nonjQuery/events.js
+++ b/test/nonjQuery/events.js
@@ -77,4 +77,36 @@ describe('nonjQuery - events', function () {
 
 		expect(called).toBe(1);
 	});
+
+	it('Does not fire delegated mouseenter when moving inside the matched element', function () {
+		let container = document.createElement('div');
+		let cell = document.createElement('div');
+		let child = document.createElement('span');
+		let called = 0;
+
+		cell.className = 'cell';
+		cell.appendChild(child);
+		container.appendChild(cell);
+		document.body.appendChild(container);
+
+		try {
+			DataTable.Dom.s(container).on('mouseenter', '.cell', function () {
+				called++;
+			});
+
+			child.dispatchEvent(
+				new MouseEvent('mouseover', {
+					bubbles: true,
+					relatedTarget: cell
+				})
+			);
+
+			DataTable.Dom.s(container).off('mouseenter');
+		}
+		finally {
+			container.remove();
+		}
+
+		expect(called).toBe(0);
+	});
 });


### PR DESCRIPTION
Avoid firing delegated `mouseenter` and `mouseleave` handlers when pointer movement stays inside the matched delegate target.

This contribution is offered under the DataTables project's MIT license.