### PR TITLE
Fix headless loading via. commonJS

### DIFF
--- a/build/wrapper.js
+++ b/build/wrapper.js
@@ -165,15 +165,19 @@ ${exportProps}
 function umd(script, deps, exp, filename) {
 	let amdLoad = [];
 	let commonjs = [];
+	let commonjsrequires = "";
 	let requiresDT = false;
 
+	commonjsmodules = "{" + deps.map((dep) => {
+		return `'${dep}': require('${dep}')`;
+	}).join(",") + "}";
 	for (let dep of deps) {
 		amdLoad.push(`'${dep}'`);
 
 		if (nameFromDependency(dep) === 'DataTable') {
 			commonjs.push(`
 			if (! root.DataTable) {
-				require('${dep}')(root);
+				root.DataTable = cjsModules['${dep}'](root);
 			}
 `);
 
@@ -183,8 +187,9 @@ function umd(script, deps, exp, filename) {
 			let name = nameFromDependency(dep);
 
 			commonjs.push(`
-			if (! window.DataTable.${name}) {
-				require('${dep}')(root);
+			baseModule['${dep}'] = require('${dep}');
+			if (! root.DataTable.${name}) {
+				root.DataTable.${name} = cjsModules['${dep}'](root);
 			}
 `);
 		}
@@ -221,6 +226,7 @@ function umd(script, deps, exp, filename) {
 	}
 	else if (typeof exports === 'object') {
 		// CommonJS
+		var cjsModules = ${commonjsmodules};
 		var cjsRequires = function (root) {${commonjs.join('')}		};
 
 		if (typeof window === 'undefined') {

--- a/js/util/ajax.ts
+++ b/js/util/ajax.ts
@@ -44,7 +44,7 @@ const defaults = {
 	contentType: 'application/x-www-form-urlencoded; charset=UTF-8',
 	headers: {},
 	traditional: false,
-	url: location.href
+	url: window.location.href
 } as AjaxOptions;
 
 /**


### PR DESCRIPTION
I've been tinkering with this on and off for a bit with DT 3 as suggested. The following fix #385 to the point that a script like this can run in nodeJS:

```javascript
import { JSDOM } from 'jsdom';

// Vanilla DT import or bootstrap DT import (both should work now)
import DataTable from './DataTablesSrc/built/DataTables/js/dataTables.js';
//import DataTable from './DataTablesSrc/built/DataTables/js/dataTables.bootstrap5.js';

console.log("--------------------- Creating JSDOM window");
const jsd_window = (new JSDOM('<!DOCTYPE html><html><body></body></html>')).window;
global.window = jsd_window; // NB: Creating a global window object to potentially confuse the factory function

console.log("--------------------- Creating DataTable");
const dt = DataTable(jsd_window);
console.log(dt.ext.oStdClasses.container);
```

Using EJS however is a bit of a non-starter:

* Extension-less imports (including the ones in ``dataTables.bootstrap5.mjs``) will load the ``.js`` version without ``type: "module"`` in ``package.json``. How safe this is to add I'm not sure.
* A by-product of the CommonJS mechanism is they make the ``window`` & ``document`` objects available to other code. In EJS-land, this doesn't happen, there's a long string of code (e.g. the line in the second commit) that runs on import that assumes that window or document are defined.

There doesn't seem to be an obvious solution for the latter. Going round and doing ``globalThis.window ? ...`` seems sisyphean, and wouldn't be the right window object anyway. Maybe a separate headless wrapper would work, but I've not looked into how to construct one of those yet.

And thanks again for dataTables!

My contribution is offered under and will be made available under the project's existing license (MIT).
